### PR TITLE
Fix rolling inventory stack imbalance and empty-slot residue

### DIFF
--- a/src/ingame/free_space.s
+++ b/src/ingame/free_space.s
@@ -90,7 +90,7 @@ display_build_number:
 ; ============================================================================
 .if INVENTORY_ROLLING_BUFFER {
 swap_redraw_trampoline:
-    jsr.l SwapRedrawHook_Impl
+    jsr.w SwapRedrawHook_Impl
     jsr.w 0xA2D9  ; Clear second cursor (from original $A404)
     jmp.w 0xA40A  ; Skip $84BA (game's sequential redraw), go to RTS
 
@@ -187,7 +187,7 @@ item_use_refresh_hook:
     Called after SelectItem2 to refresh display after item use
     Re-renders all visible slots to show updated quantity or empty slot
     """
-    jsr.l SwapRedrawHook_Impl
+    jsr.w SwapRedrawHook_Impl
     rts
 }
 

--- a/src/ingame/inventory_rolling.s
+++ b/src/ingame/inventory_rolling.s
@@ -620,7 +620,7 @@ menu_render_item_to_slot:
     xba  ; Swap bytes: A = slot * 256
     lsr  ; A = slot * 128
     clc
-    adc.w #0x0046  ; + 70 (64 border + 6 margin)
+    adc.w #0x0044  ; + 68 (64 border + 4 margin)
     tay  ; Y = tilemap offset (16-bit transfer)
     sep #0x20  ; 8-bit A
 
@@ -1179,8 +1179,8 @@ ClearInventorySlot:
     lsr
 ; A = slot * 128
     clc
-    adc.w #0x0046
-; + 70 (64 border + 6 margin)
+    adc.w #0x0044
+; + 68 (64 border + 4 margin)
     tay
 ; Y = tilemap offset (16-bit)
     sep #0x20
@@ -1410,17 +1410,28 @@ _clear_count:
     sta (0x29), y
 
 _skip_to_rts:
-; Modify return address to skip to DrawItemSlot's RTS at $A222
-    pla
-; Pop low byte of return address
-    pla
-; Pop high byte of return address
-    lda #0xA2
-; Push high byte first
+; Replace the entire DrawItemSlot return chain so we land on the RTS at $01:A222
+; instead of falling back to $A205 (NOPs + colon write).
+;
+; Stack on entry to Impl (pushed by trampoline + caller, top first):
+;   [JSL Impl return: PCL, PCH, PB ($01)]
+;   [JSR check_and_clear_count return: PCL, PCH ($A204)]
+;   [DrawItemSlot caller's return ...]
+;
+; Pop both the JSL Impl return (3 bytes) AND the JSR trampoline return (2 bytes),
+; then push a synthetic return to $01:A222 (RTS) for our RTL.
+    pla  ; PCL of JSL Impl return
+    pla  ; PCH of JSL Impl return
+    pla  ; PB  of JSL Impl return
+    pla  ; PCL of JSR check_and_clear_count return
+    pla  ; PCH of JSR check_and_clear_count return
+; Stack top now = DrawItemSlot's own caller return.
+; Push return for RTL: $01:A221 (so RTL lands PC=$01:A222 = RTS).
+    lda #0x01
     pha
-; (RTS expects high byte deeper in stack)
+    lda #0xA2
+    pha
     lda #0x21
-; Push low byte: $A222 - 1 = $A221
     pha
 
 _normal_return:
@@ -1474,8 +1485,8 @@ _circ_slot_done:
     lsr
 ; A = slot * 128
     clc
-    adc.w #0x0006
-; + 6 (margin only, $29 already includes border)
+    adc.w #0x0004
+; + 4 (margin only, $29 already includes border)
     tay
 ; Y = tilemap offset
     rts


### PR DESCRIPTION
## Summary

Three rolling-inventory bugs in the field-menu Items list:

**Stack imbalance (BRK on item swap).** `swap_redraw_trampoline` and `item_use_refresh_hook` called the bank-$01 `SwapRedrawHook_Impl` trampoline with `jsr.l`. The trampoline ends in `rts` (its bank-$21 body returns via `rtl`), so each long-call leaked one byte. After `SelectItem2`'s swap path returned, the leak cascaded through the menu coroutine chain and eventually hit a BRK once a corrupted return was popped. Switched both sites to `jsr.w`.

**Items rendered one tile too far right.** `menu_render_item_to_slot`, `ClearInventorySlot`, and `circular_slot_calc` started at slot+$46 (3-tile left margin), which placed item rows behind the cursor sprite. Shifted to +$44 (2-tile margin) for all three sites.

**Phantom count for empty slots.** `CheckAndClearCount_Impl`'s `_skip_to_rts` only popped the JSL Impl return (3 bytes). The outer `jsr.w check_and_clear_count` return (\$A204) was still on the stack, so the RTL to \$A222 was followed by an RTS that fell back to \$A205 - the NOP gap and the full count-render code at \$A208. Empty slots ended up with a misaligned count (tile \$04 with attrs \$FF/\$80/\$00) one byte off in the right column, sticking around once a slot had been emptied. Now pops both returns (5 bytes) and pushes a synthetic \$01:A221 so RTL lands on the real \$A222 RTS.

## Test plan

- [x] Open Items menu with full inventory — cursor sits flush with the first item glyph (no 1-tile gap).
- [x] Use a stackable item to zero a slot — that slot renders blank with no phantom colon/digits in the count column.
- [x] Use until inventory has fewer than 10 items — empty rows past the last item stay blank.
- [x] Swap two items in the same column — menu does not BRK.
- [x] Trash an item with the trashcan slot — icon redraws cleanly when another item replaces it.