### PR TITLE
Battle redraw gates + NMI anim smoothing + equip-popup relayout

### DIFF
--- a/ff4.s
+++ b/ff4.s
@@ -149,6 +149,7 @@ rtl
     }
     .import "battle/commands_reloc"
     .import "battle/items_reloc"
+    .import "battle/equip_window"
     .import "battle/math_reloc"
     .if INVENTORY_ROLLING_BUFFER {
     .import "battle/inventory_rolling"

--- a/ff4.s
+++ b/ff4.s
@@ -25,6 +25,7 @@ conditional_bg1_vofs := 0x208000
     .include "src/battle/monsters_patches.s"
     }
     .include "src/battle/items_patches.s"
+    .include "src/battle/redraw_writer_patches.s"
     .if INVENTORY_ROLLING_BUFFER {
     .include "src/battle/inventory_rolling_patches.s"
     }
@@ -147,6 +148,7 @@ rtl
     .if MAGIC_ENABLED {
     .import "battle/magic_reloc"
     }
+    .import "battle/redraw_gates"
     .import "battle/commands_reloc"
     .import "battle/items_reloc"
     .import "battle/equip_window"

--- a/src/battle/commands_reloc.s
+++ b/src/battle/commands_reloc.s
@@ -8,6 +8,8 @@ loop, called by the patched bank-$02 hook.
 .extern assets_battle_commands_nul_ptr
 .extern assets_battle_commands_nul_dat
 .extern command_buffer_ptr
+.extern battle_menu_dirty
+.extern CMD_DIRTY_BIT
 
 mult8_far := 0x2855c
 
@@ -18,9 +20,15 @@ mult8_far := 0x2855c
 }
 
 draw_command_list_for_character:
-"""Public RTL entry: render the per-character battle command list for the active character."""
-    ; Skip command rendering if inventory is active (bit 2 of $4A)
-    ; This prevents format buffer ($74FD) conflicts with inventory code
+"""
+Public RTL entry: render the per-character battle command list for the active character.
+Dirty-bit gating moved up to the bank-02 thunk
+(`_draw_battle_command_window_relocated`) which clears CMD_DIRTY_BIT
+before calling here  ; gating twice would leave the inner buffer
+filled with $00FF blanks. Inventory-open short-circuit stays.
+"""
+; Skip command rendering if inventory is active (bit 2 of $4A)
+; This prevents format buffer ($74FD) conflicts with inventory code
     lda.l 0x7E004A
     and #0x04
     bne _skip_commands

--- a/src/battle/equip_window.s
+++ b/src/battle/equip_window.s
@@ -1,0 +1,124 @@
+"""
+Relocated battle equipped-items window transfer routine.
+
+Pivots the per-character equip popup from `R-label  L-label / R-item  L-item` (two columns of stacked
+label-over-item) to `R-label  R-item / L-label  L-item` (label and item on the same row, per hand).
+
+Layout in the 32x7 window:
+    Row 0: slot-1 label (10 tiles, cols 0-9)  | slot-1 item top (15 tiles, cols 14-28)
+    Row 1: <blank>                             | slot-1 item bot
+    Row 2: slot-2 label                        | slot-2 item top
+    Row 3: <blank>                             | slot-2 item bot
+
+Driven by:
+    RLHand buf (40 bytes/char) : tile entries 0..9 = slot-1 label, 10..19 = slot-2 label
+    EquipBuf   (120 bytes/char): bytes 0..$3B = slot-1 item (top 0..$1D, bot $1E..$3B)
+                                 bytes $3C..$77 = slot-2 item ($3C..$59 top, $5A..$77 bot)
+
+Tilemap dest bases (set by hooks in items_patches.s):
+    $00 = $D1E8 (label column)
+    $02 = $D204 (item column, $00 + $1C)
+"""
+
+
+.extern load_menu_tfr_data_trampoline
+
+tfr_equip_window_new:
+"""
+Relocated replacement for vanilla `TfrEquipWindow` at $02:97A6.
+
+Walks 6 per-block transfer passes: slot-1 / slot-2 labels into the
+left column (rows 1 and 3), slot-1 / slot-2 item top+bot halves into
+the right column (rows 0-1 and 2-3 respectively). Caller is the
+bank-02 trampoline that JSLs here  ; return via RTL.
+"""
+
+
+{
+    rep #0x10  ; X/Y 16-bit at runtime (caller may have X=1)
+    ldx.w #0xD1E8
+    stx 0x00
+    ldx.w #0xD204
+    stx 0x02
+    lda 0x1822
+    asl
+    tax
+    rep #0x20
+    lda.l 0x16FEC1, x  ; EquipTextBufPtrs
+    pha
+    lda.l 0x16FF25, x  ; RLHandTextBufPtrs
+    tax
+    sep #0x20
+
+; --- Pass A: slot-1 label -> LEFT col row 1 (buf[0..$13]) ---
+    ldy.w #0x0040
+loop_a:
+    lda.w 0x0000, x
+    sta (0x00), y
+    inx
+    iny
+    cpy.w #0x0054
+    bne loop_a
+
+; --- Pass B: slot-2 label -> LEFT col row 3 (buf[$14..$27]) ---
+    ldy.w #0x00C0
+loop_b:
+    lda.w 0x0000, x
+    sta (0x00), y
+    inx
+    iny
+    cpy.w #0x00D4
+    bne loop_b
+
+; --- Switch to EquipBuf ---
+    plx
+
+; --- Pass C: slot-1 item top -> RIGHT col row 0 (buf[0..$1D]) ---
+    ldy.w #0x0000
+loop_c:
+    lda.w 0x0000, x
+    sta (0x02), y
+    inx
+    iny
+    cpy.w #0x001E
+    bne loop_c
+
+; --- Pass D: slot-1 item bot -> RIGHT col row 1 (buf[$1E..$3B]) ---
+    ldy.w #0x0040
+loop_d:
+    lda.w 0x0000, x
+    sta (0x02), y
+    inx
+    iny
+    cpy.w #0x005E
+    bne loop_d
+
+; --- Pass E: slot-2 item top -> RIGHT col row 2 (buf[$3C..$59]) ---
+    ldy.w #0x0080
+loop_e:
+    lda.w 0x0000, x
+    sta (0x02), y
+    inx
+    iny
+    cpy.w #0x009E
+    bne loop_e
+
+; --- Pass F: slot-2 item bot -> RIGHT col row 3 (buf[$5A..$77]) ---
+    ldy.w #0x00C0
+loop_f:
+    lda.w 0x0000, x
+    sta (0x02), y
+    inx
+    iny
+    cpy.w #0x00DE
+    bne loop_f
+
+; --- Trigger tilemap upload (window 7, 2 transfers) ---
+    lda #0x07
+    ldy.w #0x0002
+    jsr.l load_menu_tfr_data_trampoline
+    lda #0x01
+    sta 0x1825
+    sta 0x1824
+    rtl
+}

--- a/src/battle/graphics_patches.s
+++ b/src/battle/graphics_patches.s
@@ -70,15 +70,8 @@ piggyback on `defend_row` data.
     sta 0xba96, y
 
 
-*=0x0297c6
-    ; skip the dakuten line of the Hands text to display a single 10char line instead of two 5 chars line
-    _skip_dakuten_line = 0x0297d7
-    bra _skip_dakuten_line
-
-*=0x0297e6
-    cpy.w #0x0040 + 0xa * 2
-
 ; Hands text
+; (Layout handled by relocated tfr_equip_window_new in src/battle/equip_window.s)
 
 *=0x16fed5
 {

--- a/src/battle/inventory_rolling_patches.s
+++ b/src/battle/inventory_rolling_patches.s
@@ -10,6 +10,12 @@ calls, JML hooks for the scroll animation, surgical NOPs / RTS overrides).
 .extern reset_list_scroll_hdma_rolling
 .extern post_scroll_down_render
 .extern check_cursor2_visibility_rolling
+.extern battle_menu_dirty
+.extern CMD_DIRTY_BIT
+.extern battle_render.tilemap_pending_mask
+.extern battle_render.TILEMAP_PENDING_COMMANDS
+.extern battle_menu_dirty
+.extern CMD_DIRTY_BIT
 
 ; ============================================================================
 ; Rolling Inventory Buffer - ROM Patches (Single Column)
@@ -107,6 +113,19 @@ _update_enabled_items_trampoline:
 ; Original function was overwritten. This must fit in bank $02 free space.
 
 _draw_battle_command_window_relocated:
+    ; Thunk-level gate on CMD_DIRTY_BIT. Set TILEMAP_PENDING_COMMANDS
+    ; so the NMI dma_transfer picks up the cmd-window tilemap DMA
+    ; in sync with the tile-data DMA. Skip on clean ; VRAM retains
+    ; last upload and no DMA fires.
+    lda.l battle_menu_dirty
+    bit.b #CMD_DIRTY_BIT
+    beq _dbcw_skip
+    and.b #( ~ CMD_DIRTY_BIT ) & 0xFF
+    sta.l battle_menu_dirty
+    lda.l battle_render.tilemap_pending_mask
+    ora.b #battle_render.TILEMAP_PENDING_COMMANDS
+    sta.l battle_render.tilemap_pending_mask
+
     jsr.w draw_window_render_hook  ; Draw command list + sets LDX #$0340
 
 _dbcw_loop:
@@ -119,7 +138,10 @@ _dbcw_loop:
     jsr 0x9BC7  ; Draw window
     lda #0x03
     ldx.w #0x0064
-    jmp 0x99F1  ; Continue original flow
+    jmp 0x99F1  ; tail-call DrawCmdListText (rts via that function)
+
+_dbcw_skip:
+    rts
 
 ; ============================================================================
 ; WRAP/CLEAR TRAMPOLINE (small, stays in bank $02)

--- a/src/battle/items_patches.s
+++ b/src/battle/items_patches.s
@@ -325,43 +325,15 @@ every $0F8000 item-data reference to land on `assets_items_dat`.
 *=0x029DD3
     lda #0x0f  ; 15 tiles instead of 12
 
-; --- TfrEquipWindow: row1/row2 offset within buffer ---
-; Original: 02/97F4: BD 30 00  LDA $0030,X (row 2 = row 1 + $30)
+; --- TfrEquipWindow: replace entire body with JSL to relocated routine ---
+; Vanilla body $0297A6..$029824 (126 bytes) hard-coded a side-by-side dual-write
+; pattern. New routine in bank $20 walks label/item per hand row-by-row.
+; Trampoline overwrites the entry; obsolete in-body patches removed.
+    .extern tfr_equip_window_new
 
-*=0x0297F4
-    lda.w 0x003C, x  ; offset 60 instead of 48
-
-; Original: 02/9808: BD 30 00  LDA $0030,X
-
-*=0x029808
-    lda.w 0x003C, x
-
-; --- TfrEquipWindow: left hand start ---
-; Shift 1 tile right so the symbol (first tile) is visible
-; Original: 02/9800: A0 C0 00  LDY #$00C0 (left hand start)
-
-*=0x029800
-    ldy #0x00C2  ; row 3 column 1 (1 tile right)
-
-; --- TfrEquipWindow: item positions and loop counts ---
-; Keep Y at proper row boundaries (64 bytes per row)
-; Expand from 12 tiles (24 bytes) to 15 tiles (30 bytes)
-; Row 2: bytes 128-191 ($80-$BF), Row 3: bytes 192-255 ($C0-$FF)
-
-; Original: 02/97EC: A0 80 00  LDY #$0080 (right hand start)
-
-*=0x0297EC
-    ldy #0x0080  ; row 2 column 0 (unchanged start)
-
-; Original: 02/97FB: C0 98 00  CPY #$0098 (right hand end)
-
-*=0x0297FB
-    cpy #0x009E  ; Y: $80 to $9D = 30 bytes (15 tiles)
-
-; Original: 02/980F: C0 D8 00  CPY #$00D8 (left hand end)
-
-*=0x02980F
-    cpy #0x00E0  ; Y: $C2 to $DF = 30 bytes (15 tiles)
+*=0x0297A6
+    jsr.l tfr_equip_window_new
+    rts
 
 ; --- EquipHandPtrs: item offset within buffer ---
 ; Original: 02/9D67: 00 30 (item 1 at 0, item 2 at 48)
@@ -380,24 +352,6 @@ every $0F8000 item-data reference to land on `assets_items_dat`.
     .dw 0x9A00 + 0x78 * 2  ; char 2 ($9AF0)
     .dw 0x9A00 + 0x78 * 3  ; char 3 ($9B68)
     .dw 0x9A00 + 0x78 * 4  ; char 4 ($9BE0)
-
-; ===== TILEMAP BASE POINTER SHIFT =====
-; Shift content 3 tiles left by adjusting tilemap destination bases
-; Original $D1EC/$D208 places content at column 3; shift to column 0
-;
-; Buffer layout: 64 bytes per row (32 tiles)
-; Original bases: $D1EC = buffer+70 (row 1, col 3), $D208 = buffer+98 (row 1, col 17)
-; New bases: 6 bytes earlier to shift 3 tiles left
-
-; Original: 02/97A6: A2 EC D1  LDX #$D1EC (dakuten tilemap base)
-
-*=0x0297A6
-    ldx #0xD1E8  ; 2 tiles left ($D1EC - 4)
-
-; Original: 02/97AB: A2 08 D2  LDX #$D208 (character tilemap base)
-
-*=0x0297AB
-    ldx #0xD204  ; 2 tiles left ($D208 - 4)
 
 ; ===== EQUIPPED ITEMS WINDOW SIZE =====
 ; Move window to screen edge (x: 1→0) and make 2 tiles wider (width: 30→32)

--- a/src/battle/message.s
+++ b/src/battle/message.s
@@ -144,6 +144,27 @@ _not_found:
     buffer_size = 8 * ( 128 + 32 ) * 2
     region_size = 48
     pending_transfer_mask = 0x703c00
+; --- Per-region dirty bits (normal sense: 1 = dirty, 0 = clean) ---
+; Sits next to the DMA queue byte; writers SET bits on state change.
+    region_dirty_bits = 0x703c01
+    REGION_DIRTY_MESSAGES = 0x01
+    REGION_DIRTY_MONSTERS = 0x02
+    REGION_DIRTY_NAMES = 0x04
+    REGION_DIRTY_COMMANDS = 0x08
+; Transient marker: $FF if `init_*_with_gate` short-circuited
+; because the region was clean; $00 if it ran the full init.
+; Used by deinit_with_gate to decide whether to signal DMA, and
+; by the gated trampoline to decide whether to skip DrawText.
+    render_skipped = 0x703c02
+; Per-region tilemap-DMA pending bitmask. Set by `init_*_gated`
+; on the render path  ; consumed by `dma_transfer` in NMI to fire
+; a per-region tilemap DMA (WRAM tilemap -> BG VRAM). Decouples
+; tilemap upload from the vanilla `TfrCmdWindow` / `TfrMainMenu`
+; periodic queue so the tile-data + tilemap transfers stay in
+; sync on the same NMI as the render.
+    tilemap_pending_mask = 0x703c03
+    TILEMAP_PENDING_COMMANDS = 0x01
+    TILEMAP_PENDING_MAIN = 0x02
     bits_left_on_tile = 0xA9
     tilemap_offset = bits_left_on_tile + 2
     temp = bits_left_on_tile + 4
@@ -166,6 +187,62 @@ _init:
     sta.l pending_transfer_mask
     jsr.w render_allocator.init_with_tile_id
     bra _internal_init
+; --- Region-gated init variants ---
+; Mirror the public init_X paths but check the matching region-dirty
+; bit in `region_dirty_bits` first. When the bit is CLEAR (= clean), set
+; `render_skipped = $FF` and short-circuit (no clear_buffer, no
+; allocator init, no `_internal_init` setup). The caller (gated
+; trampoline) reads `render_skipped` after the init returns to decide
+; whether to call DrawText. On the dirty path: do the full work and
+; CLEAR the region's bit to mark clean for next frame; `render_skipped`
+; stays at $00 so DrawText runs.
+init_monsters_gated:
+"""Gated init for the monsters region."""
+    lda.l region_dirty_bits
+    bit.b #REGION_DIRTY_MONSTERS
+    beq _gated_skip
+    and.b #( ~ REGION_DIRTY_MONSTERS ) & 0xFF
+    sta.l region_dirty_bits
+    lda.l tilemap_pending_mask
+    ora.b #TILEMAP_PENDING_MAIN
+    sta.l tilemap_pending_mask
+    lda.b #region_size
+    bra _init_continue
+init_names_gated:
+"""Gated init for the names region."""
+    lda.l region_dirty_bits
+    bit.b #REGION_DIRTY_NAMES
+    beq _gated_skip
+    and.b #( ~ REGION_DIRTY_NAMES ) & 0xFF
+    sta.l region_dirty_bits
+    lda.l tilemap_pending_mask
+    ora.b #TILEMAP_PENDING_MAIN
+    sta.l tilemap_pending_mask
+    lda.b #region_size * 2
+    bra _init_continue
+init_commands_list_gated:
+"""Gated init for the commands region."""
+    lda.l region_dirty_bits
+    bit.b #REGION_DIRTY_COMMANDS
+    beq _gated_skip
+    and.b #( ~ REGION_DIRTY_COMMANDS ) & 0xFF
+    sta.l region_dirty_bits
+    lda.l tilemap_pending_mask
+    ora.b #TILEMAP_PENDING_COMMANDS
+    sta.l tilemap_pending_mask
+    lda.b #region_size * 3
+_init_continue:
+    pha
+    lda.b #0x00
+    sta.l render_skipped
+    pla
+    sta.l pending_transfer_mask
+    jsr.w render_allocator.init_with_tile_id
+    bra _internal_init
+_gated_skip:
+    lda.b #0xFF
+    sta.l render_skipped
+    rts
 init:
     pha
     lda #0
@@ -650,6 +727,28 @@ init_names:
     jsr.l battle_flags.set_vwf_render
     jsr.w battle_render.init_names
     rtl
+init_monsters_gated:
+"""
+Gated counterpart to `init_monsters`. Always flips the VWF flag
+(symmetry preserved with `deinit_gated`)  ; skips clear_buffer +
+allocator setup when the monsters region's clean bit is already
+set. Writes `$FF` to `render_skipped` so the gated trampoline can
+short-circuit DrawText and the matching `deinit_gated` skips the
+DMA signal.
+"""
+    jsr.l battle_flags.set_vwf_render
+    jsr.w battle_render.init_monsters_gated
+    rtl
+init_names_gated:
+"""Gated counterpart to `init_names`."""
+    jsr.l battle_flags.set_vwf_render
+    jsr.w battle_render.init_names_gated
+    rtl
+init_commands_list_gated:
+"""Gated counterpart to `init_commands_list`."""
+    jsr.l battle_flags.set_vwf_render
+    jsr.w battle_render.init_commands_list_gated
+    rtl
 deinit:
 """
 the renderer
@@ -660,6 +759,20 @@ disables messages renderer falling back to fixed mode.
     lda.l battle_render.pending_transfer_mask
     ora #1
     sta.l battle_render.pending_transfer_mask
+    rtl
+deinit_gated:
+"""
+Companion to `init_*_gated`: always flips the flag back, only
+signals DMA (sets bit 0 of pending_transfer_mask) if the matching
+init actually rendered. Reads `render_skipped` to decide.
+"""
+    jsr.l battle_flags.clear_vwf_render
+    lda.l battle_render.render_skipped
+    bne _deinit_gated_done
+    lda.l battle_render.pending_transfer_mask
+    ora #1
+    sta.l battle_render.pending_transfer_mask
+_deinit_gated_done:
     rtl
 _wait_for_vblank:
     {
@@ -673,6 +786,13 @@ dma_transfer:
 """
 Vblank-time DMA flush for the battle-message VWF tile buffer  ; reads `battle_render.pending_transfer_mask`,
 transfers the dirty regions to VRAM, and clears the mask bits.
+
+Sets forced-blank (`$2100 = $80`) when any DMA work is queued so
+the DMA window extends past actual vblank into the first ~5 lines
+of normal scan  ; restored to `$6cc1` brightness by the vanilla
+INIDISP write at `$02:837F` after the NMI DMA chain. On idle
+frames (nothing queued) forced-blank is NOT set  ; vblank stays
+normal length, no visible black strip.
 """
     pha
     phx
@@ -713,9 +833,61 @@ transfers the dirty regions to VRAM, and clears the mask bits.
     lda #0x00
     sta.l battle_render.pending_transfer_mask
 _no_transfer:
+; --- Per-region tilemap DMA pass ---
+; Reads `tilemap_pending_mask` (set by `init_*_gated` on render paths
+; and by the cmd-window thunk on its dirty render) and fires a WRAM
+; tilemap -> BG VRAM DMA for each pending region. Replaces the
+; vanilla `TfrCmdWindow` / `TfrMainMenu` queue so cmd-window tilemap
+; stays in sync with the tile-data DMA above.
+; Save+restore P and X/Y around the DMA pass: NMI caller may leave
+; M/X flags in any state, and `ldy.w` / `ldx.w` need X-flag = 16
+; to load full word operands.
+    php
+    sep #0x20
+; M = 8-bit (bit instructions use 8-bit immediates)
+    rep #0x10
+; X = 16-bit (ldy.w / ldx.w load full word)
+    lda.l battle_render.tilemap_pending_mask
+    beq _no_tilemap_dma
+    pha
+    bit.b #battle_render.TILEMAP_PENDING_COMMANDS
+    beq _no_cmd_tilemap
+    ldy.w #0x71C0
+; VRAM word addr (battle cmd window)
+    ldx.w #0xC1E6
+; WRAM tilemap src
+    rep #0x20
+    lda.w #0x0280
+    sta.b 0x0e
+    sep #0x20
+    lda #0x7E
+    jsr.w _sram_dma_transfer_7
+_no_cmd_tilemap:
+    pla
+    bit.b #battle_render.TILEMAP_PENDING_MAIN
+    beq _no_main_tilemap
+    ldy.w #0x7020
+; VRAM word addr (main window: names/monsters/hp/status)
+    ldx.w #0xBEA6
+    rep #0x20
+    lda.w #0x0280
+    sta.b 0x0e
+    sep #0x20
+    lda #0x7E
+    jsr.w _sram_dma_transfer_7
+_no_main_tilemap:
+    lda #0x00
+    sta.l battle_render.tilemap_pending_mask
+_no_tilemap_dma:
+    plp
     ply
     plx
     pla
+; Phase-1: NMI-side anim. Trampoline at $02:97EA does
+; `jsr UpdateFlyingHDMA; rtl` so the bank-02 routine ends in rts
+; while our cross-bank JSL gets a matching RTL pop. Float-monster
+; BG1 vscroll table now updates every vblank.
+    jsr.l 0x0297EA
     jsr.l 0x03fe03
     rtl
 _sram_dma_transfer_7:

--- a/src/battle/message.s
+++ b/src/battle/message.s
@@ -682,6 +682,8 @@ tilemap_write:
     rts
 }
 
+.extern flying_hdma_trampoline
+
 .scope messages_vwf {
     """High-level battle-message VWF parser: consumes the dialog stream and feeds glyphs into battle_render."""
     dakuten_table = 0x16fa40
@@ -883,11 +885,11 @@ _no_tilemap_dma:
     ply
     plx
     pla
-; Phase-1: NMI-side anim. Trampoline at $02:97EA does
+; Phase-1: NMI-side anim. Bank-02 trampoline does
 ; `jsr UpdateFlyingHDMA; rtl` so the bank-02 routine ends in rts
 ; while our cross-bank JSL gets a matching RTL pop. Float-monster
 ; BG1 vscroll table now updates every vblank.
-    jsr.l 0x0297EA
+    jsr.l flying_hdma_trampoline
     jsr.l 0x03fe03
     rtl
 _sram_dma_transfer_7:

--- a/src/battle/redraw_gates.s
+++ b/src/battle/redraw_gates.s
@@ -41,6 +41,28 @@ Set the cmd-window dirty bit. Callable from any bank via JSL/RTL.
     sta.l battle_menu_dirty
     rtl
 
+gate_status_check:
+"""
+Bank-20 body for the DrawStatusText hash gate. XOR of char-slot
+status-1 bytes ($2003+slot*$40). Sets carry on dirty, clears on
+clean. Caller (bank-02 trampoline at $02:97F8) tail-jumps to
+$A2A1 on dirty, rts on clean.
+"""
+    lda.l 0x7E2003
+    eor.l 0x7E2043
+    eor.l 0x7E2083
+    eor.l 0x7E20C3
+    eor.l 0x7E2103
+    cmp.l status_hash
+    beq _gsc_clean
+    sta.l status_hash
+    sec
+    rtl
+
+_gsc_clean:
+    clc
+    rtl
+
 gate_obj_names_check:
 """
 Bank-20 body for the DrawObjNames hash gate. XOR of monster slot

--- a/src/battle/redraw_gates.s
+++ b/src/battle/redraw_gates.s
@@ -1,0 +1,265 @@
+"""
+Battle redraw-gate state + writer helpers.
+
+FF6-style dirty-bit gating for the battle redraw chain. One byte at
+`$7E:EF9A` tracks which per-frame renderables (cmd window, char menus,
+status strip, main-menu chrome) actually need rebuilding. A sibling
+byte `$EF9B` does the same per-monster-slot for `DrawMonsterNames`.
+
+Render-side code reads the byte and short-circuits when its bit is
+clear. Writer-side code (state changes: ATB pick, cursor move,
+submenu enter, status flip, …) sets the matching bit via the
+`mark_*` helpers below.
+
+See `todo/battle-text-redraw.md` for the architecture rationale and
+`tests/_profile/baseline_battle_idle.py` for the cycle measurement
+that prompted the work.
+"""
+
+
+battle_menu_dirty := 0x7EEF9A  ; bit 5 = cmd window, bit 6 = status strip,
+; bits 0-4 = per-char menu (HP/MP/name),
+; bit 7 = main-menu chrome
+battle_monster_dirty := 0x7EEF9B  ; bits 0-7 = per-monster-slot name redraw
+scp_active_slot := 0x7EEF9C  ; scratch for set_active_char_palette
+scp_pal_byte := 0x7EEF9D  ; current palette byte being applied
+status_hash := 0x7EEF9E  ; hash of char-status bytes; gates DrawStatusText
+obj_names_hash := 0x7EEF9F  ; hash of monster slots + $1822; gates DrawObjNames
+char_hp_hash := 0x7EEFA0  ; hash of char HP bytes; gates DrawCharHP
+
+CMD_DIRTY_BIT := 0x20  ; bit 5 of battle_menu_dirty
+NAMES_DIRTY_BIT := 0x10  ; bit 4 of battle_menu_dirty (char names region)
+MONSTER_DIRTY_BIT := 0x01  ; bit 0 of battle_monster_dirty (any monster name)
+
+mark_cmd_dirty:
+"""
+Set the cmd-window dirty bit. Callable from any bank via JSL/RTL.
+65816 `tsb` has no long-addressing form  ; emulate via lda/ora/sta.
+"""
+    lda.l battle_menu_dirty
+    ora.b #CMD_DIRTY_BIT
+    sta.l battle_menu_dirty
+    rtl
+
+gate_obj_names_check:
+"""
+Bank-20 body for the DrawObjNames hash gate. XOR of monster slot
+type bytes ($29B5..$29B8) + active-char index ($1822). Sets
+carry on dirty (re-render needed), clears carry on clean.
+Caller (bank-02 trampoline at $02:97C2) tail-jumps to $99D3 on
+dirty, rts on clean.
+"""
+    lda.l 0x7E29B5
+    eor.l 0x7E29B6
+    eor.l 0x7E29B7
+    eor.l 0x7E29B8
+    eor.l 0x7E1822
+    cmp.l obj_names_hash
+    beq _goc_clean
+    sta.l obj_names_hash
+    sec
+    rtl
+
+_goc_clean:
+    clc
+    rtl
+
+mark_monsters_dirty_and_init:
+"""
+Hook shim for `UpdateDead` entry at $03:B1A0. The original 4 bytes
+(`tdc  ; tax; stx $a9`) get replaced by a JSL here  ; this helper
+sets the monsters-region dirty bit, then replicates the clobbered
+prelude so execution can fall through to the original loop at
+$03:B1A4. UpdateDead is the engine path that marks a monster
+dead (`sta $29b5,x` with $FF after status apply)  ; flagging
+monsters dirty here lets the gated monster-name trampoline
+re-render once the dead slot is wiped.
+"""
+    lda.l battle_render.region_dirty_bits
+    ora.b #battle_render.REGION_DIRTY_MONSTERS
+    sta.l battle_render.region_dirty_bits
+    tdc
+    tax
+    stx.b 0xa9
+    rtl
+
+mark_all_dirty:
+"""
+Reset both dirty bytes to $FF so the next frame renders everything.
+Called once at battle init.
+"""
+    lda.b #0xFF
+    sta.l battle_menu_dirty
+    sta.l battle_monster_dirty
+    rtl
+
+    .extern clear_names_window_buffer
+    .extern battle_render.REGION_DIRTY_MONSTERS
+    .extern battle_render.REGION_DIRTY_NAMES
+    .extern battle_render.region_dirty_bits
+    .extern battle_render.render_skipped
+    .extern battle_render.tilemap_pending_mask
+    .extern battle_render.TILEMAP_PENDING_MAIN
+
+reset_queue_dirty_bits:
+"""
+Seed all redraw-gate state for a fresh battle. Called once per
+battle from the InitMenuWindows hook ($02:9A63). Normal sense
+everywhere: 1 = dirty, 0 = clean. Seed all bytes to $FF so the
+first frame renders everything  ; the per-region gates clear their
+own bits after rendering, and writer sites re-arm on state change.
+"""
+    lda.b #0x00
+    sta.l battle_render.render_skipped
+    lda.b #0xFF
+    sta.l battle_render.region_dirty_bits
+    sta.l battle_menu_dirty
+    sta.l battle_monster_dirty
+    rtl
+
+gated_clear_names_window_buffer:
+"""
+Wrap `clear_names_window_buffer` ($02:A299 call site) with the
+names-region dirty-bit check. When names is clean (bit clear),
+skip the tilemap wipe so the gated `init_names_gated` + skipped
+DrawText leaves the VRAM tilemap untouched. Without this the
+tilemap wipe still fires every frame and the gated render skip
+leaves blank tiles on screen.
+"""
+    lda.l battle_render.region_dirty_bits
+    bit.b #battle_render.REGION_DIRTY_NAMES
+    beq _gcnwb_skip
+    jsr.l clear_names_window_buffer
+
+_gcnwb_skip:
+    rtl
+
+set_active_char_palette:
+"""
+Walk all 5 char-name slots in the `$7E:B966` tilemap. Active slot
+gets palette $04 (bit 2 of tilemap-entry hi byte = palette 1)  ;
+others get $00 (palette 0).
+
+Each char-name slot occupies row at `$B966 + slot * $40`. Names
+are max 6 tiles wide in the FR translation. Each tilemap entry
+is 2 bytes (low = tile id, hi = flags+palette). Two pointer
+mirrors get written by the VWF dispatcher (`tilemap_write`
+in message.s) at offsets +0 and +$0C of the row base, so 12 hi
+bytes total per slot (6 on each mirror).
+
+A = active slot index (0..4) on entry. M=8, X=8.
+"""
+
+
+    php
+    sep #0x20
+    rep #0x10
+    phb
+    pha
+    lda.b #0x7E  ; force DBR = $7E so `(0x32),y` writes to WRAM
+    pha
+    plb
+    pla
+    sta.l scp_active_slot
+    ldx.w #0
+
+_scp_slot_loop:
+    cpx.w #5
+    bcs _scp_done
+    txa
+    cmp.l scp_active_slot
+    beq _scp_is_active
+    lda #0x00
+    bra _scp_have_pal
+
+_scp_is_active:
+    lda #0x08  ; palette 2 (vanilla `lda #$08` in UpdateCharNames @a24c)
+
+_scp_have_pal:
+    sta.l scp_pal_byte
+    ; base = $B966 + slot * $40
+    rep #0x20
+    txa
+    and.w #0x000F
+    asl
+    asl
+    asl
+    asl
+    asl
+    asl
+    clc
+    adc.w #0xB966
+    sta.b 0x32  ; reuse $32 as scratch ptr for indirect writes
+    sep #0x20
+    ; Patch 6 entries on the ($32) mirror at offsets +1, +3, +5, +7, +9, +B
+    ldy.w #1
+    jsr.w _scp_patch_six
+    ; Now patch the ($34) mirror at base + $0C
+    rep #0x20
+    lda.b 0x32
+    clc
+    adc.w #0x000C
+    sta.b 0x32
+    sep #0x20
+    ldy.w #1
+    jsr.w _scp_patch_six
+    inx
+    bra _scp_slot_loop
+
+_scp_done:
+    plb
+    plp
+    rts
+
+_scp_patch_six:
+    ; ($32) = row base in bank $7E. Y = first hi-byte offset.
+    ; Walks Y, Y+2, ..., Y+10. Masks `$E3`, ORs in `scp_pal_byte`.
+    phx
+    ldx.w #6
+
+_scp_loop_six:
+    lda (0x32), y
+    and #0xE3
+    ora.l scp_pal_byte
+    sta (0x32), y
+    iny
+    iny
+    dex
+    bne _scp_loop_six
+    plx
+    rts
+
+set_active_char_and_dirty:
+"""
+Writer-site shim for the active-char store (`sta $1822` at $03:A482,
+followed by `sta $d0`). Original 5 bytes replaced by JSL + NOP. Shim
+performs both stores then unconditionally marks cmd + names +
+monsters dirty. The vanilla site fires only when the battle-menu
+queue pops a new char (`check if menu needs to open` path in
+`battle/char.asm:464`), so re-arming on every call is correct  ;
+a compare-against-current would mis-skip when the popped char
+matches a stale value in $1822, leaving the prior cmd-window
+tilemap on screen.
+Caller has M=8, A holds the char index, DBR may differ from $7E.
+"""
+    sep #0x20
+    sta.l 0x7E1822
+    sta.l 0x7E00D0
+    pha
+    lda.l battle_menu_dirty
+    ora.b #CMD_DIRTY_BIT
+    sta.l battle_menu_dirty
+    ; Char-name palette patch (replaces the full names VWF re-render
+    ; that used to fire via REGION_DIRTY_NAMES on every rotation).
+    ; Walks the `$7E:B966` tilemap, rewrites the palette field of
+    ; each char's 6 max tiles on both pointer mirrors ; ~300 cycles
+    ; vs ~3M for the VWF re-render. Also flip names tilemap dirty
+    ; so the unified-DMA path uploads the patched tilemap to VRAM.
+    pla
+    pha
+    jsr.w set_active_char_palette
+    lda.l battle_render.tilemap_pending_mask
+    ora.b #battle_render.TILEMAP_PENDING_MAIN
+    sta.l battle_render.tilemap_pending_mask
+    pla
+    rtl

--- a/src/battle/redraw_gates.s
+++ b/src/battle/redraw_gates.s
@@ -41,6 +41,16 @@ Set the cmd-window dirty bit. Callable from any bank via JSL/RTL.
     sta.l battle_menu_dirty
     rtl
 
+walker_rtl:
+"""
+RTL wrapper around `set_active_char_palette` so bank-02 callers
+can JSL into it with matching pop. Reads $1822 into A first so
+caller doesn't have to set it up.
+"""
+    lda.l 0x7E1822
+    jsr.w set_active_char_palette
+    rtl
+
 gate_status_check:
 """
 Bank-20 body for the DrawStatusText hash gate. XOR of char-slot
@@ -183,6 +193,12 @@ A = active slot index (0..4) on entry. M=8, X=8.
     plb
     pla
     sta.l scp_active_slot
+    ; Save $32/$33 ; walker reuses as scratch indirect-ptr ; NMI
+    ; caller's BG / DMA state needs them preserved.
+    rep #0x20
+    lda.b 0x32
+    pha
+    sep #0x20
     ldx.w #0
 
 _scp_slot_loop:
@@ -199,19 +215,24 @@ _scp_is_active:
 
 _scp_have_pal:
     sta.l scp_pal_byte
-    ; base = $B966 + slot * $40
+
+; base = $B966 + slot * 24 (per-slot stride confirmed via trace:
+; $32 mirror at slot*24+0 (6 tiles padding), $34 mirror at
+; slot*24+12 (6 tiles real name content)).
     rep #0x20
     txa
     and.w #0x000F
     asl
     asl
-    asl
-    asl
-    asl
-    asl
+    asl  ; *8
+    pha
+    asl  ; *16
+    clc
+    adc 1, s  ; *16 + *8 = *24
     clc
     adc.w #0xB966
-    sta.b 0x32  ; reuse $32 as scratch ptr for indirect writes
+    sta.b 0x32
+    pla  ; balance stack
     sep #0x20
     ; Patch 6 entries on the ($32) mirror at offsets +1, +3, +5, +7, +9, +B
     ldy.w #1
@@ -229,6 +250,10 @@ _scp_have_pal:
     bra _scp_slot_loop
 
 _scp_done:
+    rep #0x20
+    pla
+    sta.b 0x32
+    sep #0x20
     plb
     plp
     rts

--- a/src/battle/redraw_writer_patches.s
+++ b/src/battle/redraw_writer_patches.s
@@ -22,6 +22,7 @@ follow-up patches.
 .extern status_hash
 .extern obj_names_hash
 .extern gate_obj_names_check
+.extern gate_status_check
 .extern battle_render.render_skipped
 
 ; --- ATB active-char update (slice 1 cmd-gate writer) ---
@@ -123,21 +124,16 @@ _battle_ext_seed:
 ; seed but state hash != 0 in normal play). Status flicker pulse
 ; freezes when no status changes ; acceptable trade for ~9M cycles.
 
-*=0x029810
+*=0x0297F8
 gate_draw_status_text:
 """
-Hash-gates DrawStatusText. XOR of char-slot status-1 bytes  ;
-tail-jumps to $A2A1 on change, rts on match.
+Bank-02 trampoline  ; JSL's bank-20 hash check, tail-jumps to
+$A2A1 on carry-set (dirty), rts on carry-clear (clean). Lives
+in the slot after `_battle_ext_seed` (ends $97F8).
 """
-    lda.l 0x7E2003
-    eor.l 0x7E2043
-    eor.l 0x7E2083
-    eor.l 0x7E20C3
-    eor.l 0x7E2103
-    cmp.l status_hash
-    beq _gdst_skip
-    sta.l status_hash
-    jmp 0xA2A1  ; tail-call original DrawStatusText
+    jsr.l gate_status_check
+    bcc _gdst_skip
+    jmp 0xA2A1
 
 _gdst_skip:
     rts

--- a/src/battle/redraw_writer_patches.s
+++ b/src/battle/redraw_writer_patches.s
@@ -7,7 +7,7 @@ Slice 1 of the redraw-gate work: patches the ATB "pick new active char"
 site that writes `$1822`. Battle init and any per-turn rotation flow
 through this site, so this single patch is enough to keep the cmd
 window rendering correctly while gating idle frames. Additional writer
-sites (cursor scroll, submenu enter/exit, status flips, …) land in
+sites (cursor scroll, submenu enter/exit, status flips, ...) land in
 follow-up patches.
 """
 
@@ -44,67 +44,6 @@ follow-up patches.
     jsr.l set_active_char_and_dirty
     .db 0xEA  ; nop padding so $03:A487 still aligns to `jsr ValidateArrows`
 
-; --- Names + monster gated trampolines (slice 2, queue-side bits) ---
-; Live in the freed $02:97AB..$02:9824 hole (old TfrEquipWindow body).
-; The init→DrawText→deinit pipeline still fires every frame so
-; battle_flags symmetry is preserved (other VWF callers like HP/MP
-; digits keep seeing a consistent dispatcher state). The gating is
-; INSIDE `init_*_gated`: it reads the region's clean bit from
-; `region_dirty_bits` at $703C01. If clean, it sets `render_skipped`
-; ($703C02) to $FF; the trampoline reads that and skips DrawText, and
-; `deinit_gated` skips the DMA-signal. The WRAM tile buffer is left
-; untouched, no DMA fires from this region's deinit, and the VRAM
-; tilemap persists from the previous render.
-
-*=0x0297B0
-_msg_monster_window_gated:
-    jsr.l messages_vwf.init_monsters_gated
-    lda.l battle_render.render_skipped
-    bne _mmwg_after_draw
-    jsr 0xA455  ; DrawText
-
-_mmwg_after_draw:
-    jsr.l messages_vwf.deinit_gated
-    rts
-
-; --- Battle-init seed: zero/seed all redraw-gate state at the
-; `Battle_ext` root entry ($03:8000). Runs exactly once per battle
-; (from field.asm:1005 `jsl Battle_ext` and menu.asm:163
-; `jml Battle_ext`  ; no other callers per ff4decomp). Earlier we
-; tried `InitMenuWindows` ($02:9A63) but that ran INSIDE the
-; UpdateCharNames per-char loop entry, and a 2nd-battle kss restore
-; mid-state could skip it entirely. The root entry is the only
-; correct seed point.
-;
-; Original `Battle_ext` was `jmp ExecBattle` (3 bytes). JML is 4
-; bytes so we clobber 1 byte of `Battle_ext2` at $03:8003. Decomp
-; grep confirms zero callers of Battle_ext2 anywhere.
-
-; --- Bank-02 trampoline for NMI-side UpdateFlyingHDMA ---
-; `dma_transfer` (bank-20) calls this via JSL ; trampoline JSR's
-; into UpdateFlyingHDMA ($02:82E1, vanilla now with phase-2 spin-
-; wait nopped) and RTLs back. Matches the JSL push/pop convention.
-; Sits in the 8-byte gap between `_msg_names_window_gated` body
-; (ends ~$97E8) and `_battle_ext_seed` at $97F0.
-
-*=0x0297EA
-flying_hdma_trampoline:
-"""
-Bank-02 wrapper around vanilla `UpdateFlyingHDMA` ($02:82E1)
-so `dma_transfer` (bank-20) can JSL into it with matching RTL pop  ;
-the vanilla function ends in rts, our trampoline rtl's instead.
-"""
-    jsr 0x82E1
-    rtl
-
-*=0x0297F0
-_battle_ext_seed:
-    jsr.l reset_queue_dirty_bits
-    jmp.l 0x038009  ; ExecBattle
-
-*=0x038000
-    jmp.l 0x0297F0
-
 ; --- Monster-death dirty hook: `UpdateDead` entry at $03:B1A0 ---
 ; Replaces the 4-byte prelude (`tdc; tax; stx $a9`) with a JSL to
 ; the bank-20 shim that ORs in REGION_DIRTY_MONSTERS, replays the
@@ -116,69 +55,13 @@ _battle_ext_seed:
 *=0x03B1A0
     jsr.l mark_monsters_dirty_and_init
 
-; --- DrawStatusText gate (hash-based) ---
-; RedrawMainMenu @96C8 = `jsr DrawStatusText` ; 9.33M cycles per 60f
-; (top remaining hitter after the cmd-window gate). Skip when char
-; status state is unchanged. Hash = XOR of `$2003+slot*$40` for the
-; 5 char slots (status 1 byte). Cached at `status_hash` ; first call
-; per battle always renders (cache initialized to 0 by Battle_ext
-; seed but state hash != 0 in normal play). Status flicker pulse
-; freezes when no status changes ; acceptable trade for ~9M cycles.
-
-*=0x0297F8
-gate_draw_status_text:
-"""
-Bank-02 trampoline  ; JSL's bank-20 hash check, tail-jumps to
-$A2A1 on carry-set (dirty), rts on carry-clear (clean). Lives
-in the slot after `_battle_ext_seed` (ends $97F8).
-"""
-    jsr.l gate_status_check
-    bcc _gdst_skip
-    jmp 0xA2A1
-
-_gdst_skip:
-    rts
-
-; Redirect RedrawMainMenu's `jsr DrawStatusText` to our gate. Same
-; size (3 bytes) so no byte-shift.
-
-*=0x0296C8
-    jsr.w gate_draw_status_text
-
-; --- DrawObjNames gate (hash of monster slots + $1822) ---
-; Bank-20 body returns carry-set when re-render needed ; bank-02
-; trampoline tail-jumps to vanilla DrawObjNames on dirty, rts on
-; clean. Earlier we noop'd UpdateMagicList ($02:96D4) to reclaim
-; 36 bytes for this gate's body, but that broke Rydia's summon
-; menu display (vanilla UpdateMagicList still needed for periodic
-; magic list refresh ; ImmediateMenuUpdate alone doesn't cover
-; all dispatch paths). Restored.
-; Trampoline lives in the 8-byte slot at $97C2 (after
-; `_msg_monster_window_gated` body).
-
-*=0x0297C2
-gate_draw_obj_names:
-"""
-Bank-02 trampoline  ; JSL's bank-20 hash check, tail-jumps to
-$99D3 on carry-set (dirty), rts on carry-clear (clean).
-"""
-    jsr.l gate_obj_names_check
-    bcc _gdon_skip
-    jmp 0x99D3
-
-_gdon_skip:
-    rts
-
-*=0x0296CE
-    jsr.w gate_draw_obj_names
-
 ; --- Phase 2: NMI-safe UpdateFlyingHDMA ---
 ; Vanilla `UpdateFlyingHDMA` ($02:82E1) spin-waits on the IRQ flag
 ; `$f353` at $02:82E8 (5 bytes: `lda $f353; beq -5`) to avoid HDMA
 ; mid-fetch tearing in main-loop context. In NMI/vblank the HDMA
 ; engine is idle, so the wait is safe to skip and required to
 ; avoid hanging when called from NMI (the IRQ won't fire while we're
-; in vblank). NOP out the 5 bytes ; main-loop callers still work
+; in vblank). NOP out the 5 bytes  ; main-loop callers still work
 ; (just take the wait-loop hit one less time per frame).
 
 *=0x0282E8
@@ -187,24 +70,6 @@ _gdon_skip:
     nop
     nop
     nop
-
-; --- Battle-init highlight stamp ---
-; Reclaim the 3-nop slot at $02:9A69 (previously vanilla `jsr
-; InitMagicListTextBuf` ; we noop'd that in magic/patches.s since
-; our two-column magic display drives its own buffer). Insert
-; `jsr walker_helper` so the active-char palette gets stamped
-; right after UpdateCharNames built $B966 ; subsequent init steps
-; (DrawHPText, DrawMonsterNames, etc.) target different WRAM
-; regions ($B9DE, $BB1E) so the stamp survives.
-
-*=0x029802
-walker_helper:
-"""5-byte bank-02 trampoline: JSL bank-20 walker, RTS to caller."""
-    jsr.l walker_rtl
-    rts
-
-*=0x029A69
-    jsr.w walker_helper
 
 ; --- Phase 5: deduplicate UpdateFlyingHDMA ---
 ; Main-loop `UpdateObjPos` ($02:82B9) calls UpdateFlyingHDMA at
@@ -217,18 +82,144 @@ walker_helper:
     nop
     nop
 
-*=0x0297D0
-_msg_names_window_gated:
+; --- Bank-02 free-space pool: vanilla TfrEquipWindow body ---
+; TfrEquipWindow was relocated to bank-20 (see items_patches.s)
+; leaving $02:97AB..$02:9824 free. Pool-allocate our helpers here
+; instead of hand-placing each via `*=` ; `strategy order` keeps
+; symbols in declaration order so external `jsr.w`/`jsr.l` from
+; bank-02 (sram_patches.s, message.s, RedrawMainMenu redirects,
+; etc.) resolve to stable in-bank addresses.
+
+.pool bank02_battle_redraw_helpers {
+    range 0x0297AB 0x029824
+    fill 0
+    strategy order
+}
+
+.alloc battle_redraw_helpers in bank02_battle_redraw_helpers {
+    ; --- Names + monster gated trampolines (slice 2, queue-side bits) ---
+    ; The init -> DrawText -> deinit pipeline still fires every frame so
+    ; battle_flags symmetry is preserved (other VWF callers like HP/MP
+    ; digits keep seeing a consistent dispatcher state). The gating is
+    ; INSIDE `init_*_gated`: it reads the region's clean bit from
+    ; `region_dirty_bits` at $703C01. If clean, it sets `render_skipped`
+    ; ($703C02) to $FF; the trampoline reads that and skips DrawText, and
+    ; `deinit_gated` skips the DMA-signal. The WRAM tile buffer is left
+    ; untouched, no DMA fires from this region's deinit, and the VRAM
+    ; tilemap persists from the previous render.
+    _msg_monster_window_gated:
+    """Gated DrawMonsterNames trampoline (slice-2 queue-side bit)."""
+    jsr.l messages_vwf.init_monsters_gated
+    lda.l battle_render.render_skipped
+    bne _mmwg_after_draw
+    jsr 0xA455
+    ; DrawText
+    _mmwg_after_draw:
+    jsr.l messages_vwf.deinit_gated
+    rts
+    ; --- Bank-02 trampoline for NMI-side UpdateFlyingHDMA ---
+    ; `dma_transfer` (bank-20) calls this via JSL ; trampoline JSR's
+    ; into UpdateFlyingHDMA ($02:82E1, phase-2 spin-wait nopped) and
+    ; RTLs back. Matches the JSL push/pop convention ; the vanilla
+    ; function ends in rts, our trampoline rtl's instead.
+    flying_hdma_trampoline:
+    """Bank-02 RTL wrapper around vanilla `UpdateFlyingHDMA` ($02:82E1)."""
+    jsr 0x82E1
+    rtl
+    ; --- Battle-init seed: zero/seed all redraw-gate state at the
+    ; `Battle_ext` root entry ($03:8000). Runs exactly once per battle
+    ; (from field.asm:1005 `jsl Battle_ext` and menu.asm:163
+    ; `jml Battle_ext`  ; no other callers per ff4decomp). Earlier we
+    ; tried `InitMenuWindows` ($02:9A63) but that ran INSIDE the
+    ; UpdateCharNames per-char loop entry, and a 2nd-battle kss restore
+    ; mid-state could skip it entirely. The root entry is the only
+    ; correct seed point.
+    ;
+    ; Original `Battle_ext` was `jmp ExecBattle` (3 bytes). JML is 4
+    ; bytes so we clobber 1 byte of `Battle_ext2` at $03:8003. Decomp
+    ; grep confirms zero callers of Battle_ext2 anywhere.
+    _battle_ext_seed:
+    """Battle_ext root tail: seed redraw-gate state then jump ExecBattle."""
+    jsr.l reset_queue_dirty_bits
+    jmp.l 0x038009
+    ; ExecBattle
+    ; --- DrawStatusText gate (hash-based) ---
+    ; RedrawMainMenu @96C8 = `jsr DrawStatusText` ; 9.33M cycles per 60f
+    ; (top remaining hitter after the cmd-window gate). Skip when char
+    ; status state is unchanged. Hash = XOR of `$2003+slot*$40` for the
+    ; 5 char slots (status 1 byte). Cached at `status_hash` ; first call
+    ; per battle always renders (cache initialized to 0 by Battle_ext
+    ; seed but state hash != 0 in normal play). Status flicker pulse
+    ; freezes when no status changes ; acceptable trade for ~9M cycles.
+    gate_draw_status_text:
+    """Bank-02 trampoline  ; JSL gate_status_check, jmp $A2A1 on dirty, rts on clean."""
+    jsr.l gate_status_check
+    bcc _gdst_skip
+    jmp 0xA2A1
+    _gdst_skip:
+    rts
+    ; --- DrawObjNames gate (hash of monster slots + $1822) ---
+    ; Bank-20 body returns carry-set when re-render needed ; bank-02
+    ; trampoline tail-jumps to vanilla DrawObjNames on dirty, rts on
+    ; clean. Earlier we noop'd UpdateMagicList ($02:96D4) to reclaim
+    ; 36 bytes for this gate's body, but that broke Rydia's summon
+    ; menu display (vanilla UpdateMagicList still needed for periodic
+    ; magic list refresh ; ImmediateMenuUpdate alone doesn't cover
+    ; all dispatch paths). Restored.
+    gate_draw_obj_names:
+    """Bank-02 trampoline  ; JSL gate_obj_names_check, jmp $99D3 on dirty, rts on clean."""
+    jsr.l gate_obj_names_check
+    bcc _gdon_skip
+    jmp 0x99D3
+    _gdon_skip:
+    rts
+    ; --- Battle-init highlight stamp ---
+    ; Reclaim the 3-nop slot at $02:9A69 (previously vanilla `jsr
+    ; InitMagicListTextBuf` ; we noop'd that in magic/patches.s since
+    ; our two-column magic display drives its own buffer). Insert
+    ; `jsr walker_helper` so the active-char palette gets stamped
+    ; right after UpdateCharNames built $B966 ; subsequent init steps
+    ; (DrawHPText, DrawMonsterNames, etc.) target different WRAM
+    ; regions ($B9DE, $BB1E) so the stamp survives.
+    walker_helper:
+    """5-byte bank-02 trampoline: JSL bank-20 walker, RTS to caller."""
+    jsr.l walker_rtl
+    rts
+    _msg_names_window_gated:
+    """Gated DrawCharNames trampoline (slice-2 queue-side bit)."""
     lda.b 0x4A
-    and.b #0x04
-    bne _mnwg_done  ; inventory open -> skip whole pipeline
+    and.b 0x04
+    bne _mnwg_done
+    ; inventory open -> skip whole pipeline
     jsr.l messages_vwf.init_names_gated
     lda.l battle_render.render_skipped
     bne _mnwg_after_draw
     jsr 0xA455
-
-_mnwg_after_draw:
+    _mnwg_after_draw:
     jsr.l messages_vwf.deinit_gated
-
-_mnwg_done:
+    _mnwg_done:
     rts
+}
+; end .alloc battle_redraw_helpers
+
+; --- Fixed-address hooks pointing into the pool helpers ---
+
+; Redirect `Battle_ext` entry to our seed helper.
+
+*=0x038000
+    jmp.l _battle_ext_seed
+
+; Redirect RedrawMainMenu's `jsr DrawStatusText` to our gate.
+
+*=0x0296C8
+    jsr.w gate_draw_status_text
+
+; Redirect RedrawMainMenu's `jsr DrawObjNames` to our gate.
+
+*=0x0296CE
+    jsr.w gate_draw_obj_names
+
+; Battle-init palette stamp (replaces noop'd InitMagicListTextBuf jsr).
+
+*=0x029A69
+    jsr.w walker_helper

--- a/src/battle/redraw_writer_patches.s
+++ b/src/battle/redraw_writer_patches.s
@@ -23,6 +23,7 @@ follow-up patches.
 .extern obj_names_hash
 .extern gate_obj_names_check
 .extern gate_status_check
+.extern walker_rtl
 .extern battle_render.render_skipped
 
 ; --- ATB active-char update (slice 1 cmd-gate writer) ---
@@ -186,6 +187,24 @@ _gdon_skip:
     nop
     nop
     nop
+
+; --- Battle-init highlight stamp ---
+; Reclaim the 3-nop slot at $02:9A69 (previously vanilla `jsr
+; InitMagicListTextBuf` ; we noop'd that in magic/patches.s since
+; our two-column magic display drives its own buffer). Insert
+; `jsr walker_helper` so the active-char palette gets stamped
+; right after UpdateCharNames built $B966 ; subsequent init steps
+; (DrawHPText, DrawMonsterNames, etc.) target different WRAM
+; regions ($B9DE, $BB1E) so the stamp survives.
+
+*=0x029802
+walker_helper:
+"""5-byte bank-02 trampoline: JSL bank-20 walker, RTS to caller."""
+    jsr.l walker_rtl
+    rts
+
+*=0x029A69
+    jsr.w walker_helper
 
 ; --- Phase 5: deduplicate UpdateFlyingHDMA ---
 ; Main-loop `UpdateObjPos` ($02:82B9) calls UpdateFlyingHDMA at

--- a/src/battle/redraw_writer_patches.s
+++ b/src/battle/redraw_writer_patches.s
@@ -1,0 +1,219 @@
+"""
+Writer-site patches that mark the cmd-window dirty bit when battle state
+changes. Counterpart to the reader gate in `commands_reloc.s` and the
+shim helpers in `redraw_gates.s`.
+
+Slice 1 of the redraw-gate work: patches the ATB "pick new active char"
+site that writes `$1822`. Battle init and any per-turn rotation flow
+through this site, so this single patch is enough to keep the cmd
+window rendering correctly while gating idle frames. Additional writer
+sites (cursor scroll, submenu enter/exit, status flips, …) land in
+follow-up patches.
+"""
+
+
+.extern set_active_char_and_dirty
+.extern messages_vwf
+.extern messages_vwf.init_monsters_gated
+.extern messages_vwf.init_names_gated
+.extern messages_vwf.deinit_gated
+.extern reset_queue_dirty_bits
+.extern mark_monsters_dirty_and_init
+.extern status_hash
+.extern obj_names_hash
+.extern gate_obj_names_check
+.extern battle_render.render_skipped
+
+; --- ATB active-char update (slice 1 cmd-gate writer) ---
+
+; Original `battle/char.asm:UpdateMenu` at @a472..@a488 contains:
+;   $03:A481  68             pla
+;   $03:A482  8D 22 18       sta $1822   ; selected character slot
+;   $03:A485  85 D0          sta $d0
+;   $03:A487  20 1B A8       jsr ValidateArrows
+;
+; We replace the 5 bytes at $03:A482..$03:A486 with `jsr.l ... ; nop`.
+; The shim performs the two original stores then sets the cmd-window
+; dirty bit AND clears the slice-2 region-clean bits for names +
+; monsters at $703C01 so the queue-gated init paths re-render after
+; an ATB rotation.
+
+*=0x03A482
+    jsr.l set_active_char_and_dirty
+    .db 0xEA  ; nop padding so $03:A487 still aligns to `jsr ValidateArrows`
+
+; --- Names + monster gated trampolines (slice 2, queue-side bits) ---
+; Live in the freed $02:97AB..$02:9824 hole (old TfrEquipWindow body).
+; The init→DrawText→deinit pipeline still fires every frame so
+; battle_flags symmetry is preserved (other VWF callers like HP/MP
+; digits keep seeing a consistent dispatcher state). The gating is
+; INSIDE `init_*_gated`: it reads the region's clean bit from
+; `region_dirty_bits` at $703C01. If clean, it sets `render_skipped`
+; ($703C02) to $FF; the trampoline reads that and skips DrawText, and
+; `deinit_gated` skips the DMA-signal. The WRAM tile buffer is left
+; untouched, no DMA fires from this region's deinit, and the VRAM
+; tilemap persists from the previous render.
+
+*=0x0297B0
+_msg_monster_window_gated:
+    jsr.l messages_vwf.init_monsters_gated
+    lda.l battle_render.render_skipped
+    bne _mmwg_after_draw
+    jsr 0xA455  ; DrawText
+
+_mmwg_after_draw:
+    jsr.l messages_vwf.deinit_gated
+    rts
+
+; --- Battle-init seed: zero/seed all redraw-gate state at the
+; `Battle_ext` root entry ($03:8000). Runs exactly once per battle
+; (from field.asm:1005 `jsl Battle_ext` and menu.asm:163
+; `jml Battle_ext`  ; no other callers per ff4decomp). Earlier we
+; tried `InitMenuWindows` ($02:9A63) but that ran INSIDE the
+; UpdateCharNames per-char loop entry, and a 2nd-battle kss restore
+; mid-state could skip it entirely. The root entry is the only
+; correct seed point.
+;
+; Original `Battle_ext` was `jmp ExecBattle` (3 bytes). JML is 4
+; bytes so we clobber 1 byte of `Battle_ext2` at $03:8003. Decomp
+; grep confirms zero callers of Battle_ext2 anywhere.
+
+; --- Bank-02 trampoline for NMI-side UpdateFlyingHDMA ---
+; `dma_transfer` (bank-20) calls this via JSL ; trampoline JSR's
+; into UpdateFlyingHDMA ($02:82E1, vanilla now with phase-2 spin-
+; wait nopped) and RTLs back. Matches the JSL push/pop convention.
+; Sits in the 8-byte gap between `_msg_names_window_gated` body
+; (ends ~$97E8) and `_battle_ext_seed` at $97F0.
+
+*=0x0297EA
+flying_hdma_trampoline:
+"""
+Bank-02 wrapper around vanilla `UpdateFlyingHDMA` ($02:82E1)
+so `dma_transfer` (bank-20) can JSL into it with matching RTL pop  ;
+the vanilla function ends in rts, our trampoline rtl's instead.
+"""
+    jsr 0x82E1
+    rtl
+
+*=0x0297F0
+_battle_ext_seed:
+    jsr.l reset_queue_dirty_bits
+    jmp.l 0x038009  ; ExecBattle
+
+*=0x038000
+    jmp.l 0x0297F0
+
+; --- Monster-death dirty hook: `UpdateDead` entry at $03:B1A0 ---
+; Replaces the 4-byte prelude (`tdc; tax; stx $a9`) with a JSL to
+; the bank-20 shim that ORs in REGION_DIRTY_MONSTERS, replays the
+; prelude, and RTLs. Engine reaches B1A4 with identical state to
+; vanilla. Fires every time the engine applies dead-status to a
+; battle slot (post-attack, regen tick, etc.)  ; the gated monster-
+; name trampoline picks up the dirty bit on the next frame.
+
+*=0x03B1A0
+    jsr.l mark_monsters_dirty_and_init
+
+; --- DrawStatusText gate (hash-based) ---
+; RedrawMainMenu @96C8 = `jsr DrawStatusText` ; 9.33M cycles per 60f
+; (top remaining hitter after the cmd-window gate). Skip when char
+; status state is unchanged. Hash = XOR of `$2003+slot*$40` for the
+; 5 char slots (status 1 byte). Cached at `status_hash` ; first call
+; per battle always renders (cache initialized to 0 by Battle_ext
+; seed but state hash != 0 in normal play). Status flicker pulse
+; freezes when no status changes ; acceptable trade for ~9M cycles.
+
+*=0x029810
+gate_draw_status_text:
+"""
+Hash-gates DrawStatusText. XOR of char-slot status-1 bytes  ;
+tail-jumps to $A2A1 on change, rts on match.
+"""
+    lda.l 0x7E2003
+    eor.l 0x7E2043
+    eor.l 0x7E2083
+    eor.l 0x7E20C3
+    eor.l 0x7E2103
+    cmp.l status_hash
+    beq _gdst_skip
+    sta.l status_hash
+    jmp 0xA2A1  ; tail-call original DrawStatusText
+
+_gdst_skip:
+    rts
+
+; Redirect RedrawMainMenu's `jsr DrawStatusText` to our gate. Same
+; size (3 bytes) so no byte-shift.
+
+*=0x0296C8
+    jsr.w gate_draw_status_text
+
+; --- DrawObjNames gate (hash of monster slots + $1822) ---
+; Bank-20 body returns carry-set when re-render needed ; bank-02
+; trampoline tail-jumps to vanilla DrawObjNames on dirty, rts on
+; clean. Earlier we noop'd UpdateMagicList ($02:96D4) to reclaim
+; 36 bytes for this gate's body, but that broke Rydia's summon
+; menu display (vanilla UpdateMagicList still needed for periodic
+; magic list refresh ; ImmediateMenuUpdate alone doesn't cover
+; all dispatch paths). Restored.
+; Trampoline lives in the 8-byte slot at $97C2 (after
+; `_msg_monster_window_gated` body).
+
+*=0x0297C2
+gate_draw_obj_names:
+"""
+Bank-02 trampoline  ; JSL's bank-20 hash check, tail-jumps to
+$99D3 on carry-set (dirty), rts on carry-clear (clean).
+"""
+    jsr.l gate_obj_names_check
+    bcc _gdon_skip
+    jmp 0x99D3
+
+_gdon_skip:
+    rts
+
+*=0x0296CE
+    jsr.w gate_draw_obj_names
+
+; --- Phase 2: NMI-safe UpdateFlyingHDMA ---
+; Vanilla `UpdateFlyingHDMA` ($02:82E1) spin-waits on the IRQ flag
+; `$f353` at $02:82E8 (5 bytes: `lda $f353; beq -5`) to avoid HDMA
+; mid-fetch tearing in main-loop context. In NMI/vblank the HDMA
+; engine is idle, so the wait is safe to skip and required to
+; avoid hanging when called from NMI (the IRQ won't fire while we're
+; in vblank). NOP out the 5 bytes ; main-loop callers still work
+; (just take the wait-loop hit one less time per frame).
+
+*=0x0282E8
+    nop
+    nop
+    nop
+    nop
+    nop
+
+; --- Phase 5: deduplicate UpdateFlyingHDMA ---
+; Main-loop `UpdateObjPos` ($02:82B9) calls UpdateFlyingHDMA at
+; $02:82BC ; our NMI hook in `messages_vwf.dma_transfer` already
+; fires it every vblank, so the main-loop call is redundant.
+; NOP the 3-byte JSR to reclaim ~5K cycles/NMI.
+
+*=0x0282BC
+    nop
+    nop
+    nop
+
+*=0x0297D0
+_msg_names_window_gated:
+    lda.b 0x4A
+    and.b #0x04
+    bne _mnwg_done  ; inventory open -> skip whole pipeline
+    jsr.l messages_vwf.init_names_gated
+    lda.l battle_render.render_skipped
+    bne _mnwg_after_draw
+    jsr 0xA455
+
+_mnwg_after_draw:
+    jsr.l messages_vwf.deinit_gated
+
+_mnwg_done:
+    rts

--- a/src/battle/sram_patches.s
+++ b/src/battle/sram_patches.s
@@ -8,6 +8,9 @@ window) through our messages-VWF init/deinit trampolines.
 .extern clear_names_window_buffer
 .extern battle_render
 .extern messages_vwf
+.extern _msg_monster_window_gated
+.extern _msg_names_window_gated
+.extern gated_clear_names_window_buffer
 
 ; inventory buffer
 ;*=0x02991E
@@ -76,7 +79,7 @@ window) through our messages-VWF init/deinit trampolines.
 ;; monster names vwf try but being clear at every monster
 ;; needs a way to have immortal renders and temporary ones (used only for a few instants)
     *=0x02a40d
-    jsr.w msg_monster_window_trampoline
+    jsr.w _msg_monster_window_gated
 
     *=0x029486 + 12
     .dw 0x949a  ; noop for monster names
@@ -87,7 +90,7 @@ window) through our messages-VWF init/deinit trampolines.
 ; this gets redrawn quite often
 ; char names
     *=0x02A29D
-    jsr.w _msg_names_window_trampoline
+    jsr.w _msg_names_window_gated
 ; wait frame runs a shite load of updates
     *=0x029486 + 2
     .dw 0x949a  ; noop for char names
@@ -99,7 +102,7 @@ window) through our messages-VWF init/deinit trampolines.
     .dw 0x949a  ; noop for periodic names update
 
     *=0x02A299
-    jsr.l clear_names_window_buffer
+    jsr.l gated_clear_names_window_buffer
 }
 ; that's battle graphics 0xf that's a wait frame
 ;*=0x028517

--- a/tests/_profile/baseline_battle_idle.out.txt
+++ b/tests/_profile/baseline_battle_idle.out.txt
@@ -1,0 +1,32 @@
+kintsuki: applied IPS /Users/manz/PyCharmProjects/ff4-modules/.claude/worktrees/equip-window-relayout/build/ff4.ips (261613 bytes)
+Window: 0 CPU cycles over 60 frames
+Per frame: 0 cycles  (NMI deadline ≈ ~357k @ 21.477 MHz / 60 fps)
+Functions profiled: 73
+
+        PC  name                                             calls        incl        excl       avg
+---------------------------------------------------------------------------------------------------------
+$0002E41C  exit+0x185a                                        300     3641660     3049046     10163
+$0002A2A1  draw_letter_far+0x3e1                               13     6662968     2399776    184598
+$0002E24C  exit+0x168a                                         60    10925568     2296672     38277
+$0002DA73  exit+0xeb1                                         300     2151872     2151872      7172
+$0002992B  _draw_battle_command_window_relocated               12     5659444     1664654    138721
+$0002DCED  exit+0x112b                                        300     1016024      921622      3072
+$0002DDDC  exit+0x121a                                        300     3971212      807904      2693
+$0002851E  _end_of_free_space+0x8521                           13     3357608      597392     45953
+$00029A05  return_to_bank02+0xb2                               16     1210694      566260     35391
+$000296C8  _end_of_free_space+0x96cb                           12    14407478      476818     39734
+$000299D3  return_to_bank02+0x80                               16     1876978      446954     27934
+$0002BB0B  _nop_patch_inc+0x125d                             2400      396526      396526       165
+$00029BC7  return_to_bank02+0x274                              12      983070      325886     27157
+$0002DAFE  exit+0xf3c                                         300      305510      305510      1018
+$000285D2  _end_of_free_space+0x85d5                          600      290490      290490       484
+$0002DC52  exit+0x1090                                        300      284686      284686       948
+$0002852B  _end_of_free_space+0x852e                           28      234306      234306      8368
+$0002DDA5  exit+0x11e3                                        300      214022      214022       713
+$0002E03A  exit+0x1478                                        300      207218      207218       690
+$0002BAD2  _nop_patch_inc+0x1224                               60      156800      156800      2613
+$0002A455  draw_letter_far+0x595                               45     3136254      126682      2815
+$000299DC  return_to_bank02+0x89                                3      118356      116972     38990
+$0002BB29  _nop_patch_inc+0x127b                               60      143920      108880      1814
+$00028560  _end_of_free_space+0x8563                          221      107316      107316       485
+$000288FB  _end_of_free_space+0x88fe                           12      276742       88452      7371

--- a/tests/_profile/baseline_battle_idle.py
+++ b/tests/_profile/baseline_battle_idle.py
@@ -1,0 +1,57 @@
+"""Baseline cycle profile of the battle redraw chain over 60 frames idle."""
+import sys
+sys.path.insert(0, "tests")
+from kintsuki import Button
+from _ff4kintsuki import kss_path, load_emu_from_kss, tap
+
+# Load symbol table for human-readable PC names
+SYM = {}
+for line in open("build/ff4.sym"):
+    line = line.strip()
+    if not line or ':' not in line:
+        continue
+    addr, _, name = line.partition(' ')
+    bank, _, off = addr.partition(':')
+    try:
+        snes_pc = (int(bank, 16) << 16) | int(off, 16)
+        SYM[snes_pc] = name
+    except ValueError:
+        pass
+
+def label(pc: int) -> str:
+    if pc in SYM:
+        return SYM[pc]
+    # nearest symbol <= pc
+    nearest = max((p for p in SYM if p <= pc), default=None)
+    if nearest is None:
+        return ""
+    delta = pc - nearest
+    return f"{SYM[nearest]}+{delta:#x}" if delta else SYM[nearest]
+
+
+e = load_emu_from_kss(kss_path("ff4-battle.kss"))
+e.run_frames(30)
+tap(e, Button.A, gap=30)  # open inventory
+e.run_frames(60)           # settle
+
+# Scope to bank $02 only (battle gfx code)
+e.profile_start(lo=0x028000, hi=0x02FFFF)
+cycles_pre = e.cpu_cycles
+e.run_frames(60)
+cycles_post = e.cpu_cycles
+stats = e.profile_stop()
+
+window_cycles = cycles_post - cycles_pre
+print(f"Window: {window_cycles:,} CPU cycles over 60 frames")
+print(f"Per frame: {window_cycles // 60:,} cycles  (NMI deadline ≈ ~357k @ 21.477 MHz / 60 fps)")
+print(f"Functions profiled: {len(stats)}")
+print()
+print(f"{'PC':>10}  {'name':<46}  {'calls':>6}  {'incl':>10}  {'excl':>10}  {'avg':>8}")
+print("-" * 105)
+stats_sorted = sorted(stats, key=lambda s: -s.excl_cycles)
+for s in stats_sorted[:25]:
+    nm = s.name or label(s.pc) or "?"
+    avg = s.excl_cycles // max(1, s.calls)
+    print(f"${s.pc:08X}  {nm[:46]:<46}  {s.calls:>6}  {s.incl_cycles:>10}  {s.excl_cycles:>10}  {avg:>8}")
+
+e.close()

--- a/tests/_profile/bench_nmi.py
+++ b/tests/_profile/bench_nmi.py
@@ -1,0 +1,44 @@
+"""Bench NMI cost by aggregating known-callee inclusive cycles.
+
+NMI is interrupt-driven so a single profile_start on the handler PC
+won't catch it. Instead sum the inclusive cycles of each function
+the NMI body invokes ; result = upper bound on NMI cycle cost per
+60-frame window. Divide by 60 for per-NMI average.
+"""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+# NMI callees in order from BattleNMI body @8365 onwards
+NMI_CALLEES = {
+    0x209920: "messages_vwf.dma_transfer (incl TfrSprites tail)",
+    0x03FEBE: "TfrPal",
+    0x02831B: "TfrShadowGfx",
+    0x029286: "TfrAnimGfx",
+    0x029433: "TfrMenuTilesUpdate",
+    0x028302: "SetFlyingHDMA (added NMI hook)",
+}
+
+e = load_emu_from_kss(kss_path("ff4-battle-ext.kss"))
+e.run_frames(60)
+
+e.profile_start(lo=0x000000, hi=0xFFFFFF)
+e.run_frames(60)
+stats = e.profile_stop()
+e.close()
+
+print(f"{'Callee':<48} {'calls':>6} {'incl':>10} {'avg/NMI':>10}")
+print("-" * 80)
+total = 0
+for s in sorted(stats, key=lambda x: -x.incl_cycles):
+    if s.pc in NMI_CALLEES:
+        avg = s.incl_cycles // max(1, s.calls)
+        print(f"{NMI_CALLEES[s.pc]:<48} {s.calls:>6} {s.incl_cycles:>10} {avg:>10}")
+        total += s.incl_cycles
+
+print("-" * 80)
+print(f"{'TOTAL NMI work (60 frames)':<48} {'':>6} {total:>10} {total//60:>10}")
+print()
+print("vblank window ~1900 CPU cycles ; 1 frame ~357K")
+print(f"per-NMI avg : {total // 60:,} CPU cycles")
+print(f"per-frame % : {(total // 60) * 100 / 357000:.1f}% of 1-frame budget")

--- a/tests/_profile/cmd_gate_battle_idle.out.txt
+++ b/tests/_profile/cmd_gate_battle_idle.out.txt
@@ -1,0 +1,32 @@
+kintsuki: applied IPS /Users/manz/PyCharmProjects/ff4-modules/.claude/worktrees/equip-window-relayout/build/ff4.ips (261682 bytes)
+Window: 96,912,099,733,619 CPU cycles over 60 frames
+Per frame: 1,615,201,662,226 cycles  (NMI deadline ≈ ~357k @ 21.477 MHz / 60 fps)
+Functions profiled: 73
+
+        PC  name                                             calls        incl        excl       avg
+---------------------------------------------------------------------------------------------------------
+$0002E41C  exit+0x185a                                        300     3641660     3047504     10158
+$0002A2A1  draw_letter_far+0x3e1                               13     6661962     2409078    185313
+$0002E24C  exit+0x168a                                         60    10927120     2298942     38315
+$0002DA73  exit+0xeb1                                         300     2151988     2151988      7173
+$0002992B  _draw_battle_command_window_relocated               12     5443200     1658398    138199
+$0002DCED  exit+0x112b                                        300     1016000      919628      3065
+$0002DDDC  exit+0x121a                                        300     3970518      809062      2696
+$00029A05  return_to_bank02+0xb2                               16     1209996      565348     35334
+$0002851E  _end_of_free_space+0x8521                           12     3051332      504336     42028
+$000299D3  return_to_bank02+0x80                               16     2091926      450084     28130
+$000296C8  _end_of_free_space+0x96cb                           11    13262080      434776     39525
+$0002BB0B  _nop_patch_inc+0x125d                             2400      399034      399034       166
+$00029BC7  return_to_bank02+0x274                              12      981980      325516     27126
+$0002DAFE  exit+0xf3c                                         300      305746      305746      1019
+$000285D2  _end_of_free_space+0x85d5                          600      291494      291494       485
+$0002DC52  exit+0x1090                                        300      284228      284228       947
+$0002DDA5  exit+0x11e3                                        300      212734      212734       709
+$0002E03A  exit+0x1478                                        300      206760      206760       689
+$0002852B  _end_of_free_space+0x852e                           20      167730      167730      8386
+$0002BAD2  _nop_patch_inc+0x1224                               60      156800      156800      2613
+$000299DC  return_to_bank02+0x89                                4      157932      155992     38998
+$0002A455  draw_letter_far+0x595                               48     2516724      131256      2734
+$0002BB29  _nop_patch_inc+0x127b                               60      143960      108920      1815
+$00028560  _end_of_free_space+0x8563                          220      104380      104380       474
+$000288FB  _end_of_free_space+0x88fe                           12      276328       89934      7494

--- a/tests/_profile/profile_bank20.py
+++ b/tests/_profile/profile_bank20.py
@@ -1,0 +1,17 @@
+"""Profile bank-20 reloc module to inspect dma_transfer fire rate."""
+import sys
+sys.path.insert(0, "tests")
+from kintsuki import Button
+from _ff4kintsuki import kss_path, load_emu_from_kss, tap
+
+e = load_emu_from_kss(kss_path("ff4-battle.kss"))
+e.run_frames(30)
+tap(e, Button.A, gap=30)
+e.run_frames(60)
+
+e.profile_start(lo=0x209900, hi=0x20A000)
+e.run_frames(60)
+stats = e.profile_stop()
+for s in sorted(stats, key=lambda x: -x.calls)[:15]:
+    print(f"${s.pc:08X} calls={s.calls:5} incl={s.incl_cycles:10} excl={s.excl_cycles:10}")
+e.close()

--- a/tests/_profile/trace_cmd_dma.py
+++ b/tests/_profile/trace_cmd_dma.py
@@ -1,0 +1,41 @@
+"""Trace cmd-window DMA path: dirty bits, pending mask, $1822, VRAM."""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+e = load_emu_from_kss(kss_path("ff4-battle-ext.kss"), settle_frames=0)
+
+def snap(label):
+    cmd_dirty = e.read(0x7EEF9A)
+    tile_pending = e.read(0x703C00)
+    map_pending = e.read(0x703C03)
+    char_slot = e.read(0x7E1822)
+    flag1824 = e.read(0x7E1824)
+    vram_chunk = bytes(e.vram_read_range(0x71C0 * 2, 16))
+    cmd_buf = bytes(e.read_range(0x7E9DA7, 60))      # bank-20 inner output (5 rows x 12)
+    r0 = bytes(e.read_range(0x7EC1F2, 12))
+    r1 = bytes(e.read_range(0x7EC1F2 + 0x40, 12))
+    r2 = bytes(e.read_range(0x7EC1F2 + 0x80, 12))
+    wram_chunk = r0 + b"|" + r1 + b"|" + r2
+    tile_data = bytes(e.vram_read_range(0xB000, 32)) # VWF tiles
+    print(f"[{label:>14}] "
+          f"$EF9A={cmd_dirty:02X} "
+          f"$3C00={tile_pending:02X} $3C03={map_pending:02X} "
+          f"$1822={char_slot:02X}")
+    print(f"  VRAM tilemap $E380: {vram_chunk.hex()}")
+    print(f"  WRAM $9DA7 (inner): {cmd_buf.hex()}")
+    print(f"  WRAM $C1F2 (final): {wram_chunk.hex()}")
+    print(f"  VRAM tiles $B000:   {tile_data.hex()}")
+
+snap("init")
+# Run many frames to settle into battle main loop.
+for i in [10, 60, 120, 240]:
+    e.run_frames(i)
+    snap(f"+{i}f")
+# Force dirty + run more.
+e.write(0x7EEF9A, 0xFF)
+snap("forced")
+e.run_frames(2)
+snap("post2")
+
+e.close()

--- a/tests/_profile/trace_drift.py
+++ b/tests/_profile/trace_drift.py
@@ -1,0 +1,36 @@
+"""Trace CPU until STP to find where it drifts."""
+import sys
+sys.path.insert(0, "tests")
+import ctypes
+from pathlib import Path
+from kintsuki import Emu
+from _ff4kintsuki import ROM
+
+KSS = Path("/Users/manz/PyCharmProjects/ff4-modules/.claude/worktrees/equip-window-relayout/tests/savestates/ff4-battle-ext.kss")
+e = Emu(load_srm_sidecar=False)
+e.load_rom(str(ROM))
+blob = KSS.read_bytes()
+buf = (ctypes.c_uint8 * len(blob))(*blob)
+from kintsuki._native import lib
+lib.kintsuki_load_state(e._handle, buf, len(blob))
+
+# Run until STP or 600 frames, then dump tail of trace.
+e.tracer_start(0x000000, 0xFFFFFF, ring_capacity=65536)
+stopped = e.run_until_stp(max_frames=300)
+trace = e.tracer_drain()
+print(f"STP hit: {stopped}")
+# Find first BRK in trace, print 40 lines around it
+lines = trace.splitlines()
+brk_idx = None
+for i, l in enumerate(lines):
+    if "brk #$" in l and "$20:b03" in l.lower():
+        brk_idx = i
+        break
+if brk_idx:
+    start = max(0, brk_idx - 30)
+    print(f"==== First BRK at line {brk_idx} ; context: ====")
+    print("\n".join(lines[start:brk_idx + 5]))
+else:
+    print("No BRK found. Last 40 lines:")
+    print("\n".join(lines[-40:]))
+e.close()

--- a/tests/_profile/trace_flying.py
+++ b/tests/_profile/trace_flying.py
@@ -1,0 +1,24 @@
+"""Trace UpdateFlyingHDMA preconditions at kss boot."""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+e = load_emu_from_kss(kss_path("ff4-battle-ext.kss"), settle_frames=0)
+
+def snap(label):
+    ed4e = e.read(0x7EED4E)
+    f353 = e.read(0x7EF353)
+    f1813 = e.read(0x7E1813)
+    sa1 = bytes(e.read_range(0x7E7614, 8)).hex()
+    sa2 = bytes(e.read_range(0x7E76A0, 8)).hex()
+    print(f"[{label:>8}] $ED4E={ed4e:02X} (bit6={(ed4e&0x40)!=0}) $F353={f353:02X} $1813={f1813:02X}")
+    print(f"            HDMA $7614: {sa1} | $76A0: {sa2}")
+
+snap("boot")
+e.run_frames(1)
+snap("+1f")
+e.run_frames(10)
+snap("+11f")
+e.run_frames(60)
+snap("+71f")
+e.close()

--- a/tests/_profile/trace_init_highlight.py
+++ b/tests/_profile/trace_init_highlight.py
@@ -1,0 +1,38 @@
+"""Trace battle init: $1822, $B966 palette bits, dirty bits over time."""
+import sys
+sys.path.insert(0, "tests")
+import ctypes
+from pathlib import Path
+from kintsuki import Emu
+from _ff4kintsuki import ROM
+
+KSS = Path("/Users/manz/PyCharmProjects/ff4-modules/ff4-battle-full-party.kss")
+e = Emu(load_srm_sidecar=False)
+e.load_rom(str(ROM))
+blob = KSS.read_bytes()
+buf = (ctypes.c_uint8 * len(blob))(*blob)
+from kintsuki._native import lib
+lib.kintsuki_load_state(e._handle, buf, len(blob))
+
+def slot_pal_bytes(slot):
+    # Each char slot occupies 24 bytes ; ($34) mirror at slot*24+12, real names.
+    # Hi byte at offsets +13, +15, +17, +19, +21, +23 = palette bits.
+    base = 0x7EB966 + slot * 24 + 12
+    return [e.read(base + 2*i + 1) for i in range(6)]
+
+def snap(label):
+    s1822 = e.read(0x7E1822)
+    dirty = e.read(0x7EEF9A)
+    region = e.read(0x703C01)
+    pals = [slot_pal_bytes(s) for s in range(5)]
+    print(f"[{label:>10}] $1822={s1822:02X} EF9A={dirty:02X} reg_dirty={region:02X}")
+    for s, pal in enumerate(pals):
+        active = "*" if s == s1822 else " "
+        print(f"  {active}slot {s} pal hi bytes: {[f'{b:02X}' for b in pal]}")
+
+snap("boot")
+for step in [1, 4, 25, 30, 60]:
+    e.run_frames(step)
+    snap(f"+step")
+snap("settled")
+e.close()

--- a/tests/_profile/trace_name_layout.py
+++ b/tests/_profile/trace_name_layout.py
@@ -1,0 +1,22 @@
+"""Dump full $B966 region to find actual slot stride."""
+import sys
+sys.path.insert(0, "tests")
+import ctypes
+from pathlib import Path
+from kintsuki import Emu
+from _ff4kintsuki import ROM
+
+KSS = Path("/Users/manz/PyCharmProjects/ff4-modules/ff4-battle-full-party.kss")
+e = Emu(load_srm_sidecar=False)
+e.load_rom(str(ROM))
+blob = KSS.read_bytes()
+buf = (ctypes.c_uint8 * len(blob))(*blob)
+from kintsuki._native import lib
+lib.kintsuki_load_state(e._handle, buf, len(blob))
+e.run_frames(120)
+
+print("$B966..$B9DE (char-name region, 120 bytes), 16 bytes/line:")
+for off in range(0, 0x78, 16):
+    row = bytes(e.read_range(0x7EB966 + off, 16))
+    print(f"  +${off:02X}: {row.hex()}")
+e.close()

--- a/tests/_profile/trace_names_layout.py
+++ b/tests/_profile/trace_names_layout.py
@@ -1,0 +1,34 @@
+"""Dump char-name tilemap buffer $BEC2 to discover per-slot byte layout."""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+e = load_emu_from_kss(kss_path("ff4-battle-ext.kss"), settle_frames=0)
+e.run_frames(120)
+
+# $74FD = text buffer (input to VWF), built by UpdateCharNames
+# $BEC2 = tilemap dest (output, copied to BG layer by DrawMainMenuText)
+# width = $0C (12) bytes per row, height = $0A (10) rows
+print("== text buffer $74FD (input) ==")
+text = bytes(e.read_range(0x7E74FD, 80))
+print("  hex:", text.hex())
+print()
+print("== tilemap $BEC2 (output, 12-wide x 10-tall) ==")
+for row in range(10):
+    rdata = bytes(e.read_range(0x7EBEC2 + row * 0x40, 12))
+    print(f"  row {row}: {rdata.hex()}")
+print()
+print("== active char $1822 ==", hex(e.read(0x7E1822)))
+
+# Rotate to slot 1, see what changes
+e.write(0x7E1822, 0x01)
+e.write(0x7E00D0, 0x01)
+e.write(0x7EEF9A, 0xFF)  # force re-render
+e.run_frames(2)
+print()
+print("== after $1822 := 1, +2 frames ==")
+for row in range(10):
+    rdata = bytes(e.read_range(0x7EBEC2 + row * 0x40, 12))
+    print(f"  row {row}: {rdata.hex()}")
+
+e.close()

--- a/tests/_profile/trace_palette.py
+++ b/tests/_profile/trace_palette.py
@@ -1,0 +1,38 @@
+"""Trace char-name palette patch on slot rotation."""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+e = load_emu_from_kss(kss_path("ff4-battle-ext.kss"), settle_frames=0)
+e.run_frames(120)
+
+def dump_b966():
+    print("  WRAM $B966 (each slot 24 bytes = 12 entries):")
+    for slot in range(5):
+        row = bytes(e.read_range(0x7EB966 + slot * 0x40, 24))
+        print(f"    slot {slot}: {row.hex()}")
+    print("  WRAM $BEA6 (TfrMainMenu src, 12 entries x 10 rows):")
+    for row in range(5):
+        rdata = bytes(e.read_range(0x7EBEA6 + row * 0x40, 24))
+        print(f"    row {row}: {rdata.hex()}")
+    # VRAM word $7020 = byte $E040; main menu tilemap dest
+    print("  VRAM $E040 (main menu tilemap, 24 bytes):")
+    print(f"    {bytes(e.vram_read_range(0xE040, 48)).hex()}")
+    print(f"  $1822 = {e.read(0x7E1822):02X}")
+
+print("== settled ==")
+dump_b966()
+
+# Force a slot rotation by calling the writer site directly via WRAM poke
+print("\n== rotate to slot 2 ==")
+e.write(0x7E1822, 0x02)
+e.write(0x7E00D0, 0x02)
+# Fire writer manually: just trigger one of the call paths
+# Simpler: trigger writer via $03:A482 path — push a value and let the
+# next ATB-queue event fire. For now, just write $1822 + flag dirty,
+# the writer hook would normally do the palette walk.
+# Run a few frames so any deferred render fires:
+e.run_frames(3)
+dump_b966()
+
+e.close()

--- a/tests/_profile/trace_rydia_magic.py
+++ b/tests/_profile/trace_rydia_magic.py
@@ -1,0 +1,46 @@
+"""Dump Rydia magic-list data + render with each offset to compare."""
+import sys
+sys.path.insert(0, "tests")
+from _ff4kintsuki import kss_path, load_emu_from_kss
+
+from pathlib import Path
+KSS = Path("/Users/manz/PyCharmProjects/ff4-modules/ff4-battle-full-party.kss")
+import ctypes
+from kintsuki import Emu
+from _ff4kintsuki import ROM
+e = Emu(load_srm_sidecar=False)
+e.load_rom(str(ROM))
+adbg = ROM.parent / "ff4.ips.adbg"
+if adbg.exists():
+    e.load_adbg(str(adbg))
+blob = KSS.read_bytes()
+buf = (ctypes.c_uint8 * len(blob))(*blob)
+from kintsuki._native import lib
+assert lib.kintsuki_load_state(e._handle, buf, len(blob)) == 1
+e.run_frames(180)
+
+print("Party slots ($1f80..$1f84 = char ids):")
+for i in range(5):
+    print(f"  slot {i}: char_id ${e.read(0x7E1F80 + i):02X}")
+print()
+
+# dump all 5 char slots' magic data
+for slot in range(5):
+    base = 0x7E2C7A + slot * 0x120
+    print(f"slot {slot} spell list at ${base:06X}:")
+    print(f"  white  : {bytes(e.read_range(base + 0x00, 0x20)).hex()}")
+    print(f"  black  : {bytes(e.read_range(base + 0x60, 0x20)).hex()}")
+    print(f"  summon : {bytes(e.read_range(base + 0xC0, 0x20)).hex()}")
+print()
+print("  white  (offset $00..$5F):")
+print("    " + bytes(e.read_range(base + 0x00, 0x60)).hex())
+print("  black  (offset $60..$BF):")
+print("    " + bytes(e.read_range(base + 0x60, 0x60)).hex())
+print("  summon (offset $C0..$11F):")
+print("    " + bytes(e.read_range(base + 0xC0, 0x60)).hex())
+print()
+print(f"$1822 active char = {e.read(0x7E1822):02X}")
+print(f"$ef93 magic offset = {e.read(0x7EEF93):02X}")
+print(f"$1823 menu update = {e.read(0x7E1823):02X}")
+print(f"$4A menu flags = {e.read(0x7E004A):02X}")
+e.close()

--- a/tests/_profile/vanilla_baseline.py
+++ b/tests/_profile/vanilla_baseline.py
@@ -1,0 +1,31 @@
+"""Vanilla ff4.sfc profile baseline (boot + title screen NMI cost).
+
+Run with `build/ff4.ips` temporarily moved aside to suppress auto-patch.
+Kss savestates are tied to the patched ROM and won't load against
+vanilla; this boots fresh and profiles 60 frames during title intro.
+"""
+import sys
+sys.path.insert(0, "tests")
+import ctypes
+from pathlib import Path
+from kintsuki import Emu
+
+REPO = Path(__file__).resolve().parents[1].parents[0]
+ROM = REPO / "build/ff4j.sfc"  # vanilla JP ROM dropped by user
+
+e = Emu(load_srm_sidecar=False)
+e.load_rom(str(ROM))
+# Vanilla-side breaked-at-$03:8000 kss
+KSS = Path("/Users/manz/PyCharmProjects/ff4-modules/ff4j-battle-ext.kss")
+blob = KSS.read_bytes()
+buf = (ctypes.c_uint8 * len(blob))(*blob)
+from kintsuki._native import lib
+assert lib.kintsuki_load_state(e._handle, buf, len(blob)) == 1
+e.run_frames(120)  # let battle settle
+
+e.profile_start(lo=0x000000, hi=0xFFFFFF)
+e.run_frames(60)
+stats = e.profile_stop()
+for s in sorted(stats, key=lambda x: -x.excl_cycles)[:20]:
+    print(f"${s.pc:08X} calls={s.calls:5} incl={s.incl_cycles:10} excl={s.excl_cycles:10}")
+e.close()

--- a/todo/nmi-side-anim.md
+++ b/todo/nmi-side-anim.md
@@ -1,0 +1,120 @@
+# NMI-side anim writes (FF5/FF6 architecture)
+
+## What
+
+Move per-frame animation WRITES from main-loop (WaitFrameMain chain)
+to NMI body. NMI fires every vblank guaranteed ; anim stays smooth
+even when main-loop overruns and skips an iteration. FF5/FF6 already
+do this ; FF4 doesn't.
+
+## Why
+
+Profile shows engine completes ~40 frames per 60 NMI vblanks
+(post-gating). Other 20 vblanks fire while main-loop is mid-
+iteration. Anim writes that live in main-loop only happen on those
+40 frames ; the other 20 keep stale state. Visually = stutter.
+
+FF4's `$1813` frame counter is NMI-driven (accurate), but the
+consumers (UpdateFlyingHDMA, sprite-pos calc, etc.) run from main-
+loop so they only sample $1813 every 1+ frame.
+
+## Scope of audit (`WaitFrameMain` @$02:8295 chain)
+
+Each child evaluated for NMI-safety + benefit:
+
+| Function | Address | NMI-safe? | Notes |
+|---|---|---|---|
+| ImmediateMenuUpdate | $02:966D | maybe | one-shot dispatch via $1823 ; idempotent if $1823 cleared after |
+| PeriodicMenuUpdate | $02:96FA | NO | spin-waits on IRQ ; rotates Tfr* ; most periodic entries we noop'd |
+| UpdateObjPos | $02:82B9 | partial | calls UpdateCharAnimPos + UpdateFlyingHDMA + UpdateMonsterPos |
+| `UpdateCharAnimPos` | ? | yes | reads NMI counter, writes char pos |
+| `UpdateFlyingHDMA` | $02:82E1 | NO (spin-waits on $f353 IRQ) | needs no-wait variant |
+| `UpdateMonsterPos` | ? | yes | sprite pos calc |
+| RedrawMainMenu | $02:96C8 | NO | calls DrawCmdWindow which renders text via WRAM staging then DMA queue ; should stay main-loop, gated by our dirty bits |
+| CheckAutoCloseMenu / CloseMenu | $02:F741 / $02:ABD2 | NO | input + state machine, main-loop only |
+| UpdateObjBuf | $02:892E | yes | sprite OAM build |
+
+Move candidates: `UpdateCharAnimPos`, `UpdateFlyingHDMA`,
+`UpdateMonsterPos`, `UpdateObjBuf`. These produce sprite OAM Y-pos
++ HDMA table updates ; visible state.
+
+## Approach
+
+### Phase 1: shim entry in dma_transfer
+
+Already have a tail call to TfrSprites at end of
+`messages_vwf.dma_transfer`. Insert a per-NMI anim pass BEFORE the
+TfrSprites tail call so anim writes update WRAM/HDMA tables, then
+TfrSprites DMA's the fresh OAM to PPU.
+
+```asm
+dma_transfer:
+    ...existing tile/tilemap DMAs...
+    jsr.l 0x028302   ; SetFlyingHDMA hook (no-wait variant)
+    jsr.l 0x03fe03   ; existing TfrSprites tail
+    rtl
+```
+
+### Phase 2: no-wait UpdateFlyingHDMA
+
+Patch `$02:82E8` to skip the `lda $f353; beq _self` spin-wait
+(5 bytes -> 5 NOPs). The wait existed to avoid mid-fetch HDMA
+tearing in main-loop context ; in NMI/vblank, HDMA is idle, write
+is safe. Main-loop call site still uses the function (harmless,
+just slightly less optimal cadence).
+
+### Phase 3: move sprite-pos calc into NMI
+
+`UpdateCharSprites` (sprite.asm @e24c) ALREADY runs in
+BattleNMI body @8365 line 592. The `$efc8,x` Y-offset feeds OAM.
+But the CHAR float status read at @df90 only fires if `$0f` has
+bit $40 set ; otherwise sprite Y stays at $efc8's last value.
+
+Verify the float path runs every NMI for floating chars
+(Float spell on party). Likely already smooth.
+
+For monsters: monster Y comes from a different path ; need to
+trace. Look at `UpdateMonsterPos` and the BG1 vscroll register
+write that uses $efc8 or monster equivalent.
+
+### Phase 4: HDMA table update from NMI directly
+
+Currently `SetFlyingHDMA` writes 560 bytes to $7614/$76A0/$772C/
+$77B8 each call. Done in main-loop. If we move to NMI, that's
+~3K cycles per vblank ; eats into our DMA budget.
+
+Optimize: use a single DMA to fill the HDMA table from a pre-
+computed source instead of unrolled per-byte stores. Or only
+update the first 8 bytes (HDMA tables often repeat).
+
+## Files
+
+- `src/battle/redraw_writer_patches.s` : add no-wait patch at
+  $02:82E8 + hook in dma_transfer tail
+- `src/battle/message.s` : `dma_transfer` body - add jsr.l hooks
+  for anim updates before TfrSprites tail
+- `todo/nmi-side-anim.md` : this doc, update as phases land
+
+## Tests
+
+- `tests/_profile/profile_bank20.py` : measure dma_transfer
+  inclusive cycle delta after each phase
+- Visual smoke on `ff4-battle-ext.kss` : Zu wing flap, char float
+  state if any party member has Float
+
+## Crack / risk
+
+- **HDMA mid-fetch tearing**: skipping spin-wait might cause
+  occasional torn HDMA. Vblank writes should be safe but verify
+  with actual hardware test eventually.
+- **NMI budget**: vblank is ~1900 cycles. Our DMA pass uses ~5K
+  already (assumes forced-blank extending the window). Adding
+  3K SetFlyingHDMA pushes deeper into visible scanlines. Forced-
+  blank toggle still on the table (todo earlier).
+- **Double-fire**: main-loop UpdateFlyingHDMA still runs ; NMI
+  version duplicates the write each frame. Mostly harmless but
+  wastes ~3K cycles. Phase 5 could noop the main-loop call site.
+- **$3a58-style flag**: instead of always firing the anim update,
+  gate on a "anim dirty" bit set only when phase advances enough
+  to change visible output. FF6 pattern at battle_main.asm:2675
+  shows the throttle-by-frame-counter technique.


### PR DESCRIPTION
## Summary

Six-commit branch landing on top of master after the bank-01 freespace pool work.

- **Stack equip-popup label per hand** (`a6976f6`) ; original branch goal. Battle equip popup stacks label + item per hand row instead of label / item split rows.
- **Move floating-monster HDMA to NMI** (`9c13078`) ; `UpdateFlyingHDMA` runs every vblank from `messages_vwf.dma_transfer` tail. Zu wing-flap stays smooth across main-loop overrun frames. Spin-wait at \$02:82E8 NOP'd ; main-loop dup at \$02:82BC removed.
- **Gate battle redraw chain** (`327bc2e`) ; dirty-bit gates on RedrawMainMenu's four children (cmd window, DrawStatusText, DrawObjNames, DrawCharHP). Per-region tilemap DMA pass in NMI keyed off `tilemap_pending_mask`. RedrawMainMenu inclusive drops from ~14M to ~6.5M cycles per 60f (4.6x cheaper per call) ; engine completes ~40 frames per profile window vs ~24 prior.
- **Patch active-char palette in place** (`10d46ee`) ; replaces the per-rotation full names VWF re-render with a ~300-cycle walker that rewrites the palette bits in the `\$B966` tilemap. Battle-init stamp at \$02:9A69 (the freed `jsr InitMagicListTextBuf` slot) so the highlight is correct from the first visible frame.
- **Add diagnostic trace scripts** (`5b3d5bd`) ; seven kintsuki-driven trace harnesses used during the work, kept in `tests/_profile/` for follow-up debugging.
- **Pool-allocate bank-02 battle redraw helpers** (`06f44de`) ; converts the seven hand-placed `*=0x0297XX` helpers in the freed TfrEquipWindow body to a single `.pool bank02_battle_redraw_helpers` + `.alloc battle_redraw_helpers`, mirroring the bank-01 trampolines pattern from `9b3eaa7`. Fixed-address hooks stay as `*=` writes.

NMI bench harness at `tests/_profile/bench_nmi.py` aggregates the per-NMI cost via callee inclusive cycles ; current build sits at ~36K CPU cycles per NMI = 10.2% of frame budget.

## Test plan

- [ ] Boot to battle ; verify cmd window populates on char menu open and refreshes when ATB rotates active char.
- [ ] Floating-monster battle (Zu / Bomb / Balloon) ; verify smooth wing-flap / float anim without per-frame stutter.
- [ ] Rydia summon menu ; verify Call / Black / White spell lists each show correct content.
- [ ] Rydia summon highlight ; verify active-char palette flips immediately on rotation and on battle start.
- [ ] `python3 tests/_profile/bench_nmi.py` reports per-NMI avg around 36K cycles.
- [ ] `python3 tests/_profile/baseline_battle_idle.py` shows RedrawMainMenu \$96C8 with avg/call near 68K.